### PR TITLE
Ref field support

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -400,6 +400,7 @@ Currently the following fields are supported:
 - DATE
 - XE
 - INDEX
+- REF
 
 .. code-block:: php
 
@@ -427,6 +428,12 @@ For instance for the INDEX field, you can do the following (See `Index Field for
     //this actually adds the index
     $section->addField('INDEX', array(), array('\\e "	" \\h "A" \\c "3"'), 'right click to update index');
 
+    //reference a book mark
+    $section->addField(
+        'REF',
+        array('name' => 'your-bookmark'),
+        array('InsertParagraphNumberRelativeContext','CreateHyperLink')
+    );
 Line
 ----
 

--- a/src/PhpWord/Element/Field.php
+++ b/src/PhpWord/Element/Field.php
@@ -84,6 +84,10 @@ class Field extends AbstractElement
             'properties' => array('StyleIdentifier' => ''),
             'options'    => array('PreserveFormat'),
         ),
+        'REF' => array(
+            'properties' => array('name' => ''),
+            'options'    => array('f', 'h', 'n', 'p', 'r', 't', 'w'),
+        ),
     );
 
     /**

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -212,4 +212,98 @@ class Field extends Text
 
         return $propertiesAndOptions;
     }
+
+    /**
+     * Writes a REF field
+     *
+     * @param \PhpOffice\PhpWord\Element\Field $element
+     */
+    protected function writeRef(\PhpOffice\PhpWord\Element\Field $element)
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $this->startElementP();
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'begin');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
+        $instruction = ' ' . $element->getType() . ' ';
+
+        foreach ($element->getProperties() as $property) {
+            $instruction .= $property . ' ';
+        }
+        foreach ($element->getOptions() as $optionKey => $optionValue) {
+            $instruction .= $this->convertRefOption($optionKey, $optionValue) . ' ';
+        }
+
+        $xmlWriter->startElement('w:r');
+        $this->writeFontStyle();
+        $xmlWriter->startElement('w:instrText');
+        $xmlWriter->writeAttribute('xml:space', 'preserve');
+        $xmlWriter->text($instruction);
+        $xmlWriter->endElement(); // w:instrText
+        $xmlWriter->endElement(); // w:r
+
+        if ($element->getText() != null) {
+            if ($element->getText() instanceof \PhpOffice\PhpWord\Element\TextRun) {
+                $containerWriter = new Container($xmlWriter, $element->getText(), true);
+                $containerWriter->write();
+
+                $xmlWriter->startElement('w:r');
+                $xmlWriter->startElement('w:instrText');
+                $xmlWriter->text('"' . $this->buildPropertiesAndOptions($element));
+                $xmlWriter->endElement(); // w:instrText
+                $xmlWriter->endElement(); // w:r
+
+                $xmlWriter->startElement('w:r');
+                $xmlWriter->startElement('w:instrText');
+                $xmlWriter->writeAttribute('xml:space', 'preserve');
+                $xmlWriter->text(' ');
+                $xmlWriter->endElement(); // w:instrText
+                $xmlWriter->endElement(); // w:r
+            }
+        }
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'separate');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:rPr');
+        $xmlWriter->startElement('w:noProof');
+        $xmlWriter->endElement(); // w:noProof
+        $xmlWriter->endElement(); // w:rPr
+        $xmlWriter->writeElement('w:t', $element->getText() != null && is_string($element->getText()) ? $element->getText() : '1');
+        $xmlWriter->endElement(); // w:r
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'end');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
+        $this->endElementP(); // w:p
+    }
+
+    private function convertRefOption($optionKey, $optionValue)
+    {
+        if ($optionKey === 'NumberSeperatorSequence') {
+            return '\\d ' . $optionValue;
+        }
+
+        switch ($optionValue) {
+            case 'IncrementAndInsertText': return '\\f';
+            case 'CreateHyperLink': return '\\h';
+            case 'NoTrailingPeriod': return '\\n';
+            case 'IncludeAboveOrBelow': return '\\p';
+            case 'InsertParagraphNumberRelativeContext': return '\\r';
+            case 'SuppressNonDelimeterNonNumericalText': return '\\t';
+            case 'InsertParagraphNumberFullContext': return '\\w';
+            default: return '';
+        }
+    }
 }

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -301,7 +301,7 @@ class Field extends Text
             case 'NoTrailingPeriod': return '\\n';
             case 'IncludeAboveOrBelow': return '\\p';
             case 'InsertParagraphNumberRelativeContext': return '\\r';
-            case 'SuppressNonDelimeterNonNumericalText': return '\\t';
+            case 'SuppressNonDelimiterNonNumericalText': return '\\t';
             case 'InsertParagraphNumberFullContext': return '\\w';
             default: return '';
         }

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -296,14 +296,22 @@ class Field extends Text
         }
 
         switch ($optionValue) {
-            case 'IncrementAndInsertText': return '\\f';
-            case 'CreateHyperLink': return '\\h';
-            case 'NoTrailingPeriod': return '\\n';
-            case 'IncludeAboveOrBelow': return '\\p';
-            case 'InsertParagraphNumberRelativeContext': return '\\r';
-            case 'SuppressNonDelimiterNonNumericalText': return '\\t';
-            case 'InsertParagraphNumberFullContext': return '\\w';
-            default: return '';
+            case 'IncrementAndInsertText':
+                return '\\f';
+            case 'CreateHyperLink':
+                return '\\h';
+            case 'NoTrailingPeriod':
+                return '\\n';
+            case 'IncludeAboveOrBelow':
+                return '\\p';
+            case 'InsertParagraphNumberRelativeContext':
+                return '\\r';
+            case 'SuppressNonDelimiterNonNumericalText':
+                return '\\t';
+            case 'InsertParagraphNumberFullContext':
+                return '\\w';
+            default:
+                return '';
         }
     }
 }

--- a/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\TestHelperDOCX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\Word2007\Field
+ */
+class FieldTest extends TestCase
+{
+    /**
+     * Executed before each method of the class
+     */
+    public function tearDown()
+    {
+        TestHelperDOCX::clear();
+    }
+
+    /**
+     * Test Field write
+     */
+    public function testWriteWithRefType()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addField(
+            'REF',
+            array(
+                'name' => 'my-bookmark',
+            ),
+            array(
+                'InsertParagraphNumberRelativeContext',
+                'CreateHyperLink',
+            )
+        );
+
+        $section->addListItem('line one item');
+        $section->addListItem('line two item');
+        $section->addBookmark('my-bookmark');
+        $section->addListItem('line three item');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $refFieldPath = '/w:document/w:body/w:p[1]/w:r[2]/w:instrText';
+
+        $this->assertTrue($doc->elementExists($refFieldPath));
+
+        $bookMarkElement = $doc->getElement($refFieldPath);
+
+        $this->assertNotNull($bookMarkElement);
+
+        $this->assertEquals(' REF my-bookmark \r \h ', $bookMarkElement->textContent);
+
+        $bookmarkPath = '/w:document/w:body/w:bookmarkStart';
+
+        $this->assertTrue($doc->elementExists($bookmarkPath));
+        $this->assertEquals('my-bookmark', $doc->getElementAttribute("$bookmarkPath", 'w:name'));
+    }
+}


### PR DESCRIPTION
### Description
PHPOffice/PHPWord currently does not support adding the field of type REF.
I would like to add a field to reference a bookmark
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)
Add REF options to $fieldsArray in PhpOffice\PhpWord\Element\Field.php
Added writeRef method to Handle REF options

```php
$textRun->addField('REF', [
      'name' => 'my-bookmark'
  ], [
      'InsertParagraphNumberRelativeContext',
      'CreateHyperLink',
  ]);

```

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
