### PR TITLE
Feature/sharefore ref filed support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpoffice/phpword",
+    "name": "shareforce/phpword",
     "description": "PHPWord - A pure PHP library for reading and writing word processing documents (OOXML, ODF, RTF, HTML, PDF)",
     "keywords": [
         "PHP", "PHPOffice", "office", "PHPWord", "word", "template", "template processor", "reader", "writer",
@@ -84,7 +84,7 @@
     },
     "autoload": {
         "psr-4": {
-            "PhpOffice\\PhpWord\\": "src/PhpWord"
+            "Shareforce\\PhpWord\\": "src/PhpWord"
         }
     },
     "extra": {

--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -400,6 +400,7 @@ Currently the following fields are supported:
 - DATE
 - XE
 - INDEX
+- REF
 
 .. code-block:: php
 
@@ -427,6 +428,12 @@ For instance for the INDEX field, you can do the following (See `Index Field for
     //this actually adds the index
     $section->addField('INDEX', array(), array('\\e "	" \\h "A" \\c "3"'), 'right click to update index');
 
+    //reference a book mark
+    $section->addField(
+        'REF',
+        array('name' => 'your-bookmark'),
+        array('InsertParagraphNumberRelativeContext','CreateHyperLink')
+    );
 Line
 ----
 

--- a/samples/Sample_01_SimpleText.php
+++ b/samples/Sample_01_SimpleText.php
@@ -1,21 +1,21 @@
 <?php
-use PhpOffice\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Font;
 
 include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s') , ' Create new PhpWord object' , EOL;
 
-$languageEnGb = new \PhpOffice\PhpWord\Style\Language(\PhpOffice\PhpWord\Style\Language::EN_GB);
+$languageEnGb = new \Shareforce\PhpWord\Style\Language(\Shareforce\PhpWord\Style\Language::EN_GB);
 
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $phpWord->getSettings()->setThemeFontLang($languageEnGb);
 
 $fontStyleName = 'rStyle';
 $phpWord->addFontStyle($fontStyleName, array('bold' => true, 'italic' => true, 'size' => 16, 'allCaps' => true, 'doubleStrikethrough' => true));
 
 $paragraphStyleName = 'pStyle';
-$phpWord->addParagraphStyle($paragraphStyleName, array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER, 'spaceAfter' => 100));
+$phpWord->addParagraphStyle($paragraphStyleName, array('alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER, 'spaceAfter' => 100));
 
 $phpWord->addTitleStyle(1, array('bold' => true), array('spaceAfter' => 240));
 
@@ -28,7 +28,7 @@ $section->addText('Hello World!');
 
 // $pStyle = new Font();
 // $pStyle->setLang()
-$section->addText('Ce texte-ci est en français.', array('lang' => \PhpOffice\PhpWord\Style\Language::FR_BE));
+$section->addText('Ce texte-ci est en français.', array('lang' => \Shareforce\PhpWord\Style\Language::FR_BE));
 
 // Two text break
 $section->addTextBreak(2);

--- a/samples/Sample_02_TabStops.php
+++ b/samples/Sample_02_TabStops.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Define styles
 $multipleTabsStyleName = 'multipleTab';
@@ -11,18 +11,18 @@ $phpWord->addParagraphStyle(
     $multipleTabsStyleName,
     array(
         'tabs' => array(
-            new \PhpOffice\PhpWord\Style\Tab('left', 1550),
-            new \PhpOffice\PhpWord\Style\Tab('center', 3200),
-            new \PhpOffice\PhpWord\Style\Tab('right', 5300),
+            new \Shareforce\PhpWord\Style\Tab('left', 1550),
+            new \Shareforce\PhpWord\Style\Tab('center', 3200),
+            new \Shareforce\PhpWord\Style\Tab('right', 5300),
         ),
     )
 );
 
 $rightTabStyleName = 'rightTab';
-$phpWord->addParagraphStyle($rightTabStyleName, array('tabs' => array(new \PhpOffice\PhpWord\Style\Tab('right', 9090))));
+$phpWord->addParagraphStyle($rightTabStyleName, array('tabs' => array(new \Shareforce\PhpWord\Style\Tab('right', 9090))));
 
 $leftTabStyleName = 'centerTab';
-$phpWord->addParagraphStyle($leftTabStyleName, array('tabs' => array(new \PhpOffice\PhpWord\Style\Tab('center', 4680))));
+$phpWord->addParagraphStyle($leftTabStyleName, array('tabs' => array(new \Shareforce\PhpWord\Style\Tab('center', 4680))));
 
 // New portrait section
 $section = $phpWord->addSection();

--- a/samples/Sample_03_Sections.php
+++ b/samples/Sample_03_Sections.php
@@ -1,11 +1,11 @@
 <?php
-use PhpOffice\PhpWord\SimpleType\VerticalJc;
+use Shareforce\PhpWord\SimpleType\VerticalJc;
 
 include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New portrait section
 $section = $phpWord->addSection(array('borderColor' => '00FF00', 'borderSize' => 12));

--- a/samples/Sample_04_Textrun.php
+++ b/samples/Sample_04_Textrun.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Define styles
 $paragraphStyleName = 'pStyle';
@@ -16,7 +16,7 @@ $coloredFontStyleName = 'ColoredText';
 $phpWord->addFontStyle($coloredFontStyleName, array('color' => 'FF8080', 'bgColor' => 'FFFFCC'));
 
 $linkFontStyleName = 'NLink';
-$phpWord->addLinkStyle($linkFontStyleName, array('color' => '0000FF', 'underline' => \PhpOffice\PhpWord\Style\Font::UNDERLINE_SINGLE));
+$phpWord->addLinkStyle($linkFontStyleName, array('color' => '0000FF', 'underline' => \Shareforce\PhpWord\Style\Font::UNDERLINE_SINGLE));
 
 // New portrait section
 $section = $phpWord->addSection();

--- a/samples/Sample_05_Multicolumn.php
+++ b/samples/Sample_05_Multicolumn.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $filler = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '
         . 'Nulla fermentum, tortor id adipiscing adipiscing, tortor turpis commodo. '
         . 'Donec vulputate iaculis metus, vel luctus dolor hendrerit ac. '

--- a/samples/Sample_06_Footnote.php
+++ b/samples/Sample_06_Footnote.php
@@ -1,13 +1,13 @@
 <?php
-use PhpOffice\PhpWord\ComplexType\FootnoteProperties;
-use PhpOffice\PhpWord\SimpleType\NumberFormat;
+use Shareforce\PhpWord\ComplexType\FootnoteProperties;
+use Shareforce\PhpWord\SimpleType\NumberFormat;
 
 include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
-\PhpOffice\PhpWord\Settings::setCompatibility(false);
+$phpWord = new \Shareforce\PhpWord\PhpWord();
+\Shareforce\PhpWord\Settings::setCompatibility(false);
 
 // Define styles
 $paragraphStyleName = 'pStyle';
@@ -20,7 +20,7 @@ $coloredFontStyleName = 'ColoredText';
 $phpWord->addFontStyle($coloredFontStyleName, array('color' => 'FF8080', 'bgColor' => 'FFFFCC'));
 
 $linkFontStyleName = 'NLink';
-$phpWord->addLinkStyle($linkFontStyleName, array('color' => '0000FF', 'underline' => \PhpOffice\PhpWord\Style\Font::UNDERLINE_SINGLE));
+$phpWord->addLinkStyle($linkFontStyleName, array('color' => '0000FF', 'underline' => \Shareforce\PhpWord\Style\Font::UNDERLINE_SINGLE));
 
 // New portrait section
 $section = $phpWord->addSection();

--- a/samples/Sample_07_TemplateCloneRow.php
+++ b/samples/Sample_07_TemplateCloneRow.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // Template processor instance creation
 echo date('H:i:s'), ' Creating new TemplateProcessor instance...', EOL;
-$templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor('resources/Sample_07_TemplateCloneRow.docx');
+$templateProcessor = new \Shareforce\PhpWord\TemplateProcessor('resources/Sample_07_TemplateCloneRow.docx');
 
 // Variables on different parts of document
 $templateProcessor->setValue('weekday', date('l'));            // On section/content

--- a/samples/Sample_08_ParagraphPagination.php
+++ b/samples/Sample_08_ParagraphPagination.php
@@ -3,11 +3,11 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $phpWord->setDefaultParagraphStyle(
     array(
-        'alignment'  => \PhpOffice\PhpWord\SimpleType\Jc::BOTH,
-        'spaceAfter' => \PhpOffice\PhpWord\Shared\Converter::pointToTwip(12),
+        'alignment'  => \Shareforce\PhpWord\SimpleType\Jc::BOTH,
+        'spaceAfter' => \Shareforce\PhpWord\Shared\Converter::pointToTwip(12),
         'spacing'    => 120,
     )
 );

--- a/samples/Sample_09_Tables.php
+++ b/samples/Sample_09_Tables.php
@@ -1,12 +1,12 @@
 <?php
-use PhpOffice\PhpWord\Shared\Converter;
-use PhpOffice\PhpWord\Style\TablePosition;
+use Shareforce\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Style\TablePosition;
 
 include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $section = $phpWord->addSection();
 $header = array('size' => 16, 'bold' => true);
 
@@ -30,10 +30,10 @@ $section->addTextBreak(1);
 $section->addText('Fancy table', $header);
 
 $fancyTableStyleName = 'Fancy Table';
-$fancyTableStyle = array('borderSize' => 6, 'borderColor' => '006699', 'cellMargin' => 80, 'alignment' => \PhpOffice\PhpWord\SimpleType\JcTable::CENTER, 'cellSpacing' => 50);
+$fancyTableStyle = array('borderSize' => 6, 'borderColor' => '006699', 'cellMargin' => 80, 'alignment' => \Shareforce\PhpWord\SimpleType\JcTable::CENTER, 'cellSpacing' => 50);
 $fancyTableFirstRowStyle = array('borderBottomSize' => 18, 'borderBottomColor' => '0000FF', 'bgColor' => '66BBFF');
 $fancyTableCellStyle = array('valign' => 'center');
-$fancyTableCellBtlrStyle = array('valign' => 'center', 'textDirection' => \PhpOffice\PhpWord\Style\Cell::TEXT_DIR_BTLR);
+$fancyTableCellBtlrStyle = array('valign' => 'center', 'textDirection' => \Shareforce\PhpWord\Style\Cell::TEXT_DIR_BTLR);
 $fancyTableFontStyle = array('bold' => true);
 $phpWord->addTableStyle($fancyTableStyleName, $fancyTableStyle, $fancyTableFirstRowStyle);
 $table = $section->addTable($fancyTableStyleName);
@@ -69,7 +69,7 @@ $fancyTableStyle = array('borderSize' => 6, 'borderColor' => '999999');
 $cellRowSpan = array('vMerge' => 'restart', 'valign' => 'center', 'bgColor' => 'FFFF00');
 $cellRowContinue = array('vMerge' => 'continue');
 $cellColSpan = array('gridSpan' => 2, 'valign' => 'center');
-$cellHCentered = array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER);
+$cellHCentered = array('alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER);
 $cellVCentered = array('valign' => 'center');
 
 $spanTableStyleName = 'Colspan Rowspan';
@@ -136,10 +136,10 @@ $row->addCell(1000)->addText('3');
 $section->addTextBreak(2);
 $section->addText('Nested table in a centered and 50% width table.', $header);
 
-$table = $section->addTable(array('width' => 50 * 50, 'unit' => 'pct', 'alignment' => \PhpOffice\PhpWord\SimpleType\JcTable::CENTER));
+$table = $section->addTable(array('width' => 50 * 50, 'unit' => 'pct', 'alignment' => \Shareforce\PhpWord\SimpleType\JcTable::CENTER));
 $cell = $table->addRow()->addCell();
 $cell->addText('This cell contains nested table.');
-$innerCell = $cell->addTable(array('alignment' => \PhpOffice\PhpWord\SimpleType\JcTable::CENTER))->addRow()->addCell();
+$innerCell = $cell->addTable(array('alignment' => \Shareforce\PhpWord\SimpleType\JcTable::CENTER))->addRow()->addCell();
 $innerCell->addText('Inside nested table');
 
 // 6. Table with floating position

--- a/samples/Sample_10_EastAsianFontStyle.php
+++ b/samples/Sample_10_EastAsianFontStyle.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $section = $phpWord->addSection();
 $header = array('size' => 16, 'bold' => true);
 //1.Use EastAisa FontStyle

--- a/samples/Sample_11_ReadWord2007.php
+++ b/samples/Sample_11_ReadWord2007.php
@@ -6,7 +6,7 @@ $name = basename(__FILE__, '.php');
 $source = __DIR__ . "/resources/{$name}.docx";
 
 echo date('H:i:s'), " Reading contents from `{$source}`", EOL;
-$phpWord = \PhpOffice\PhpWord\IOFactory::load($source);
+$phpWord = \Shareforce\PhpWord\IOFactory::load($source);
 
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);

--- a/samples/Sample_11_ReadWord97.php
+++ b/samples/Sample_11_ReadWord97.php
@@ -5,7 +5,7 @@ include_once 'Sample_Header.php';
 $name = basename(__FILE__, '.php');
 $source = "resources/{$name}.doc";
 echo date('H:i:s'), " Reading contents from `{$source}`", EOL;
-$phpWord = \PhpOffice\PhpWord\IOFactory::load($source, 'MsDoc');
+$phpWord = \Shareforce\PhpWord\IOFactory::load($source, 'MsDoc');
 
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);

--- a/samples/Sample_12_HeaderFooter.php
+++ b/samples/Sample_12_HeaderFooter.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New portrait section
 $section = $phpWord->addSection();
@@ -17,7 +17,7 @@ $cell = $table->addCell(4500);
 $textrun = $cell->addTextRun();
 $textrun->addText('This is the header with ');
 $textrun->addLink('https://github.com/PHPOffice/PHPWord', 'PHPWord on GitHub');
-$table->addCell(4500)->addImage('resources/PhpWord.png', array('width' => 80, 'height' => 80, 'alignment' => \PhpOffice\PhpWord\SimpleType\Jc::END));
+$table->addCell(4500)->addImage('resources/PhpWord.png', array('width' => 80, 'height' => 80, 'alignment' => \Shareforce\PhpWord\SimpleType\Jc::END));
 
 // Add header for all other pages
 $subsequent = $section->addHeader();
@@ -26,7 +26,7 @@ $subsequent->addImage('resources/_mars.jpg', array('width' => 80, 'height' => 80
 
 // Add footer
 $footer = $section->addFooter();
-$footer->addPreserveText('Page {PAGE} of {NUMPAGES}.', null, array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER));
+$footer->addPreserveText('Page {PAGE} of {NUMPAGES}.', null, array('alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER));
 $footer->addLink('https://github.com/PHPOffice/PHPWord', 'PHPWord on GitHub');
 
 // Write some text

--- a/samples/Sample_13_Images.php
+++ b/samples/Sample_13_Images.php
@@ -1,12 +1,12 @@
 <?php
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Element\Section;
+use Shareforce\PhpWord\Shared\Converter;
 
 include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Begin code
 $section = $phpWord->addSection();
@@ -15,7 +15,7 @@ $section->addImage('resources/_mars.jpg');
 
 printSeparator($section);
 $section->addText('Local image with styles:');
-$section->addImage('resources/_earth.jpg', array('width' => 210, 'height' => 210, 'alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER));
+$section->addImage('resources/_earth.jpg', array('width' => 210, 'height' => 210, 'alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER));
 
 // Remote image
 printSeparator($section);
@@ -58,14 +58,14 @@ $section->addText('Absolute positioning: see top right corner of page');
 $section->addImage(
     'resources/_mars.jpg',
     array(
-        'width'            => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(3),
-        'height'           => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(3),
-        'positioning'      => \PhpOffice\PhpWord\Style\Image::POSITION_ABSOLUTE,
-        'posHorizontal'    => \PhpOffice\PhpWord\Style\Image::POSITION_HORIZONTAL_RIGHT,
-        'posHorizontalRel' => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_PAGE,
-        'posVerticalRel'   => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_PAGE,
-        'marginLeft'       => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(15.5),
-        'marginTop'        => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(1.55),
+        'width'            => \Shareforce\PhpWord\Shared\Converter::cmToPixel(3),
+        'height'           => \Shareforce\PhpWord\Shared\Converter::cmToPixel(3),
+        'positioning'      => \Shareforce\PhpWord\Style\Image::POSITION_ABSOLUTE,
+        'posHorizontal'    => \Shareforce\PhpWord\Style\Image::POSITION_HORIZONTAL_RIGHT,
+        'posHorizontalRel' => \Shareforce\PhpWord\Style\Image::POSITION_RELATIVE_TO_PAGE,
+        'posVerticalRel'   => \Shareforce\PhpWord\Style\Image::POSITION_RELATIVE_TO_PAGE,
+        'marginLeft'       => \Shareforce\PhpWord\Shared\Converter::cmToPixel(15.5),
+        'marginTop'        => \Shareforce\PhpWord\Shared\Converter::cmToPixel(1.55),
     )
 );
 
@@ -76,13 +76,13 @@ $section->addText('Vertical position top relative to line');
 $section->addImage(
     'resources/_mars.jpg',
     array(
-        'width'            => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(3),
-        'height'           => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(3),
-        'positioning'      => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE,
-        'posHorizontal'    => \PhpOffice\PhpWord\Style\Image::POSITION_HORIZONTAL_CENTER,
-        'posHorizontalRel' => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_COLUMN,
-        'posVertical'      => \PhpOffice\PhpWord\Style\Image::POSITION_VERTICAL_TOP,
-        'posVerticalRel'   => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_LINE,
+        'width'            => \Shareforce\PhpWord\Shared\Converter::cmToPixel(3),
+        'height'           => \Shareforce\PhpWord\Shared\Converter::cmToPixel(3),
+        'positioning'      => \Shareforce\PhpWord\Style\Image::POSITION_RELATIVE,
+        'posHorizontal'    => \Shareforce\PhpWord\Style\Image::POSITION_HORIZONTAL_CENTER,
+        'posHorizontalRel' => \Shareforce\PhpWord\Style\Image::POSITION_RELATIVE_TO_COLUMN,
+        'posVertical'      => \Shareforce\PhpWord\Style\Image::POSITION_VERTICAL_TOP,
+        'posVerticalRel'   => \Shareforce\PhpWord\Style\Image::POSITION_RELATIVE_TO_LINE,
     )
 );
 

--- a/samples/Sample_14_ListItem.php
+++ b/samples/Sample_14_ListItem.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Define styles
 $fontStyleName = 'myOwnStyle';
@@ -24,7 +24,7 @@ $phpWord->addNumberingStyle(
     )
 );
 
-$predefinedMultilevelStyle = array('listType' => \PhpOffice\PhpWord\Style\ListItem::TYPE_NUMBER_NESTED);
+$predefinedMultilevelStyle = array('listType' => \Shareforce\PhpWord\Style\ListItem::TYPE_NUMBER_NESTED);
 
 // New section
 $section = $phpWord->addSection();

--- a/samples/Sample_15_Link.php
+++ b/samples/Sample_15_Link.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Define styles
 $linkFontStyleName = 'myOwnLinStyle';
@@ -16,7 +16,7 @@ $section = $phpWord->addSection();
 $section->addLink(
     'https://github.com/PHPOffice/PHPWord',
     'PHPWord on GitHub',
-    array('color' => '0000FF', 'underline' => \PhpOffice\PhpWord\Style\Font::UNDERLINE_SINGLE)
+    array('color' => '0000FF', 'underline' => \Shareforce\PhpWord\Style\Font::UNDERLINE_SINGLE)
 );
 $section->addTextBreak(2);
 $section->addLink('http://www.bing.com', null, $linkFontStyleName);

--- a/samples/Sample_16_Object.php
+++ b/samples/Sample_16_Object.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Begin code
 $section = $phpWord->addSection();

--- a/samples/Sample_17_TitleTOC.php
+++ b/samples/Sample_17_TitleTOC.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $phpWord->getSettings()->setUpdateFields(true);
 
 // New section

--- a/samples/Sample_18_Watermark.php
+++ b/samples/Sample_18_Watermark.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Begin code
 $section = $phpWord->addSection();

--- a/samples/Sample_19_TextBreak.php
+++ b/samples/Sample_19_TextBreak.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Define styles
 $fontStyle24 = array('size' => 24);

--- a/samples/Sample_20_BGColor.php
+++ b/samples/Sample_20_BGColor.php
@@ -3,14 +3,14 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();
 
 $section->addText(
     'This is some text highlighted using fgColor (limited to 15 colors)',
-    array('fgColor' => \PhpOffice\PhpWord\Style\Font::FGCOLOR_YELLOW)
+    array('fgColor' => \Shareforce\PhpWord\Style\Font::FGCOLOR_YELLOW)
 );
 $section->addText('This one uses bgColor and is using hex value (0xfbbb10)', array('bgColor' => 'fbbb10'));
 $section->addText('Compatible with font colors', array('color' => '0000ff', 'bgColor' => 'fbbb10'));

--- a/samples/Sample_21_TableRowRules.php
+++ b/samples/Sample_21_TableRowRules.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();
@@ -18,7 +18,7 @@ $section->addText(
 $table1 = $section->addTable(array('cellMargin' => 0, 'cellMarginRight' => 0, 'cellMarginBottom' => 0, 'cellMarginLeft' => 0));
 $table1->addRow(3750);
 $cell1 = $table1->addCell(null, array('valign' => 'top', 'borderSize' => 30, 'borderColor' => 'ff0000'));
-$cell1->addImage('./resources/_earth.jpg', array('width' => 250, 'height' => 250, 'alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER));
+$cell1->addImage('./resources/_earth.jpg', array('width' => 250, 'height' => 250, 'alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER));
 
 $section->addTextBreak();
 $section->addText("But if we set the rowStyle 'exactHeight' to true, the real row height is used, removing the textbreak:");
@@ -33,7 +33,7 @@ $table2 = $section->addTable(
 );
 $table2->addRow(3750, array('exactHeight' => true));
 $cell2 = $table2->addCell(null, array('valign' => 'top', 'borderSize' => 30, 'borderColor' => '00ff00'));
-$cell2->addImage('./resources/_earth.jpg', array('width' => 250, 'height' => 250, 'alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER));
+$cell2->addImage('./resources/_earth.jpg', array('width' => 250, 'height' => 250, 'alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER));
 
 $section->addTextBreak();
 $section->addText('In this example, image is 250px height. Rows are calculated in twips, and 1px = 15twips.');

--- a/samples/Sample_22_CheckBox.php
+++ b/samples/Sample_22_CheckBox.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();

--- a/samples/Sample_23_TemplateBlock.php
+++ b/samples/Sample_23_TemplateBlock.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // Template processor instance creation
 echo date('H:i:s') , ' Creating new TemplateProcessor instance...' , EOL;
-$templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor('resources/Sample_23_TemplateBlock.docx');
+$templateProcessor = new \Shareforce\PhpWord\TemplateProcessor('resources/Sample_23_TemplateBlock.docx');
 
 // Will clone everything between ${tag} and ${/tag}, the number of times. By default, 1.
 $templateProcessor->cloneBlock('CLONEME', 3);

--- a/samples/Sample_24_ReadODText.php
+++ b/samples/Sample_24_ReadODText.php
@@ -6,7 +6,7 @@ $name = basename(__FILE__, '.php');
 $source = __DIR__ . "/resources/{$name}.odt";
 
 echo date('H:i:s'), " Reading contents from `{$source}`", EOL;
-$phpWord = \PhpOffice\PhpWord\IOFactory::load($source, 'ODText');
+$phpWord = \Shareforce\PhpWord\IOFactory::load($source, 'ODText');
 
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);

--- a/samples/Sample_25_TextBox.php
+++ b/samples/Sample_25_TextBox.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();
@@ -11,7 +11,7 @@ $section = $phpWord->addSection();
 // In section
 $textbox = $section->addTextBox(
     array(
-        'alignment'   => \PhpOffice\PhpWord\SimpleType\Jc::CENTER,
+        'alignment'   => \Shareforce\PhpWord\SimpleType\Jc::CENTER,
         'width'       => 400,
         'height'      => 150,
         'borderSize'  => 1,

--- a/samples/Sample_26_Html.php
+++ b/samples/Sample_26_Html.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s') , ' Create new PhpWord object' , EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $phpWord->addParagraphStyle('Heading2', array('alignment' => 'center'));
 
 $section = $phpWord->addSection();
@@ -92,7 +92,7 @@ $html .= '<table align="center" style="width: 80%; border: 6px #0000FF double;">
 $html .= '<p style="margin-top: 240pt;">The text below is not visible, click on show/hide to reveil it:</p>';
 $html .= '<p style="display: none">This is hidden text</p>';
 
-\PhpOffice\PhpWord\Shared\Html::addHtml($section, $html, false, false);
+\Shareforce\PhpWord\Shared\Html::addHtml($section, $html, false, false);
 
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);

--- a/samples/Sample_27_Field.php
+++ b/samples/Sample_27_Field.php
@@ -1,12 +1,12 @@
 <?php
-use PhpOffice\PhpWord\Element\TextRun;
+use Shareforce\PhpWord\Element\TextRun;
 
 include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
-PhpOffice\PhpWord\Style::addTitleStyle(1, array('size' => 14));
+$phpWord = new \Shareforce\PhpWord\PhpWord();
+Shareforce\PhpWord\Style::addTitleStyle(1, array('size' => 14));
 
 // New section
 $section = $phpWord->addSection();
@@ -45,7 +45,7 @@ $textrun->addText('here:');
 $section->addText('The actual index:');
 $section->addField('INDEX', array(), array('\\e "	"'), 'right click to update the index');
 
-$textrun = $section->addTextRun(array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER));
+$textrun = $section->addTextRun(array('alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER));
 $textrun->addText('This is the date of lunar calendar ');
 $textrun->addField('DATE', array('dateformat' => 'd-M-yyyy H:mm:ss'), array('PreserveFormat', 'LunarCalendar'));
 $textrun->addText(' written in a textrun.');

--- a/samples/Sample_28_ReadRTF.php
+++ b/samples/Sample_28_ReadRTF.php
@@ -6,7 +6,7 @@ $name = basename(__FILE__, '.php');
 $source = __DIR__ . "/resources/{$name}.rtf";
 
 echo date('H:i:s'), " Reading contents from `{$source}`", EOL;
-$phpWord = \PhpOffice\PhpWord\IOFactory::load($source, 'RTF');
+$phpWord = \Shareforce\PhpWord\IOFactory::load($source, 'RTF');
 
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);

--- a/samples/Sample_29_Line.php
+++ b/samples/Sample_29_Line.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();
@@ -13,16 +13,16 @@ $section = $phpWord->addSection();
 $section->addText('Horizontal Line (Inline style):');
 $section->addLine(
     array(
-        'width'       => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(4),
-        'height'      => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(0),
+        'width'       => \Shareforce\PhpWord\Shared\Converter::cmToPixel(4),
+        'height'      => \Shareforce\PhpWord\Shared\Converter::cmToPixel(0),
         'positioning' => 'absolute',
     )
 );
 $section->addText('Vertical Line (Inline style):');
 $section->addLine(
     array(
-        'width'       => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(0),
-        'height'      => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(1),
+        'width'       => \Shareforce\PhpWord\Shared\Converter::cmToPixel(0),
+        'height'      => \Shareforce\PhpWord\Shared\Converter::cmToPixel(1),
         'positioning' => 'absolute',
     )
 );
@@ -32,14 +32,14 @@ $section->addTextBreak(1);
 $section->addText('Positioned Line (red):');
 $section->addLine(
     array(
-        'width'            => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(4),
-        'height'           => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(1),
+        'width'            => \Shareforce\PhpWord\Shared\Converter::cmToPixel(4),
+        'height'           => \Shareforce\PhpWord\Shared\Converter::cmToPixel(1),
         'positioning'      => 'absolute',
         'posHorizontalRel' => 'page',
         'posVerticalRel'   => 'page',
-        'marginLeft'       => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(10),
-        'marginTop'        => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(8),
-        'wrappingStyle'    => \PhpOffice\PhpWord\Style\Image::WRAPPING_STYLE_SQUARE,
+        'marginLeft'       => \Shareforce\PhpWord\Shared\Converter::cmToPixel(10),
+        'marginTop'        => \Shareforce\PhpWord\Shared\Converter::cmToPixel(8),
+        'wrappingStyle'    => \Shareforce\PhpWord\Style\Image::WRAPPING_STYLE_SQUARE,
         'color'            => 'red',
     )
 );
@@ -47,12 +47,12 @@ $section->addLine(
 $section->addText('Horizontal Formatted Line');
 $section->addLine(
     array(
-        'width'       => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(15),
-        'height'      => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(0),
+        'width'       => \Shareforce\PhpWord\Shared\Converter::cmToPixel(15),
+        'height'      => \Shareforce\PhpWord\Shared\Converter::cmToPixel(0),
         'positioning' => 'absolute',
-        'beginArrow'  => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
-        'endArrow'    => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_OVAL,
-        'dash'        => \PhpOffice\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
+        'beginArrow'  => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
+        'endArrow'    => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_OVAL,
+        'dash'        => \Shareforce\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
         'weight'      => 10,
     )
 );

--- a/samples/Sample_30_ReadHTML.php
+++ b/samples/Sample_30_ReadHTML.php
@@ -6,7 +6,7 @@ $name = basename(__FILE__, '.php');
 $source = realpath(__DIR__ . "/resources/{$name}.html");
 
 echo date('H:i:s'), " Reading contents from `{$source}`", EOL;
-$phpWord = \PhpOffice\PhpWord\IOFactory::load($source, 'HTML');
+$phpWord = \Shareforce\PhpWord\IOFactory::load($source, 'HTML');
 
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);

--- a/samples/Sample_31_Shape.php
+++ b/samples/Sample_31_Shape.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();

--- a/samples/Sample_32_Chart.php
+++ b/samples/Sample_32_Chart.php
@@ -1,11 +1,11 @@
 <?php
 include_once 'Sample_Header.php';
 
-use PhpOffice\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Shared\Converter;
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // Define styles
 $phpWord->addTitleStyle(1, array('size' => 14, 'bold' => true), array('keepNext' => true, 'spaceBefore' => 240));

--- a/samples/Sample_33_FormField.php
+++ b/samples/Sample_33_FormField.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 $phpWord->getProtection()->setEditing('forms');
 
 // New section

--- a/samples/Sample_34_SDT.php
+++ b/samples/Sample_34_SDT.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();

--- a/samples/Sample_35_InternalLink.php
+++ b/samples/Sample_35_InternalLink.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 $section = $phpWord->addSection();
 $section->addTitle('This is page 1', 1);

--- a/samples/Sample_36_RTL.php
+++ b/samples/Sample_36_RTL.php
@@ -3,7 +3,7 @@ include_once 'Sample_Header.php';
 
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New section
 $section = $phpWord->addSection();
@@ -11,17 +11,17 @@ $section = $phpWord->addSection();
 $textrun = $section->addTextRun();
 $textrun->addText('This is a Left to Right paragraph.');
 
-$textrun = $section->addTextRun(array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::END));
+$textrun = $section->addTextRun(array('alignment' => \Shareforce\PhpWord\SimpleType\Jc::END));
 $textrun->addText('سلام این یک پاراگراف راست به چپ است', array('rtl' => true));
 
 $section->addText('Table visually presented as RTL');
 $style = array('rtl' => true, 'size' => 12);
-$tableStyle = array('borderSize' => 6, 'borderColor' => '000000', 'width' => 5000, 'unit' => \PhpOffice\PhpWord\SimpleType\TblWidth::PERCENT, 'bidiVisual' => true);
+$tableStyle = array('borderSize' => 6, 'borderColor' => '000000', 'width' => 5000, 'unit' => \Shareforce\PhpWord\SimpleType\TblWidth::PERCENT, 'bidiVisual' => true);
 
 $table = $section->addTable($tableStyle);
-$cellHCentered = array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER);
-$cellHEnd = array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::END);
-$cellVCentered = array('valign' => \PhpOffice\PhpWord\Style\Cell::VALIGN_CENTER);
+$cellHCentered = array('alignment' => \Shareforce\PhpWord\SimpleType\Jc::CENTER);
+$cellHEnd = array('alignment' => \Shareforce\PhpWord\SimpleType\Jc::END);
+$cellVCentered = array('valign' => \Shareforce\PhpWord\Style\Cell::VALIGN_CENTER);
 
 //Vidually bidirectinal table
 $table->addRow();

--- a/samples/Sample_37_Comments.php
+++ b/samples/Sample_37_Comments.php
@@ -3,10 +3,10 @@ include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s') , ' Create new PhpWord object' , EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // A comment
-$comment = new \PhpOffice\PhpWord\Element\Comment('Authors name', new \DateTime(), 'my_initials');
+$comment = new \Shareforce\PhpWord\Element\Comment('Authors name', new \DateTime(), 'my_initials');
 $comment->addText('Test', array('bold' => true));
 $phpWord->addComment($comment);
 
@@ -21,7 +21,7 @@ $textrun->addText(' a test');
 $section->addTextBreak(2);
 
 // Let's create a comment that we will link to a start element and an end element
-$commentWithStartAndEnd = new \PhpOffice\PhpWord\Element\Comment('Foo Bar', new \DateTime());
+$commentWithStartAndEnd = new \Shareforce\PhpWord\Element\Comment('Foo Bar', new \DateTime());
 $commentWithStartAndEnd->addText('A comment with a start and an end');
 $phpWord->addComment($commentWithStartAndEnd);
 
@@ -36,7 +36,7 @@ $textToEndOn->setCommentRangeEnd($commentWithStartAndEnd);
 $section->addTextBreak(2);
 
 // Let's add a comment on an image
-$commentOnImage = new \PhpOffice\PhpWord\Element\Comment('Mr Smart', new \DateTime());
+$commentOnImage = new \Shareforce\PhpWord\Element\Comment('Mr Smart', new \DateTime());
 $imageComment = $commentOnImage->addTextRun();
 $imageComment->addText('Hey, Mars does look ');
 $imageComment->addText('red', array('color' => 'FF0000'));
@@ -49,7 +49,7 @@ $section->addTextBreak(2);
 // We can also do things the other way round, link the comment to the element
 $anotherText = $section->addText('another text');
 
-$comment1 = new \PhpOffice\PhpWord\Element\Comment('Authors name', new \DateTime(), 'my_initials');
+$comment1 = new \Shareforce\PhpWord\Element\Comment('Authors name', new \DateTime(), 'my_initials');
 $comment1->addText('Test', array('bold' => true));
 $comment1->setStartElement($anotherText);
 $comment1->setEndElement($anotherText);

--- a/samples/Sample_38_Protection.php
+++ b/samples/Sample_38_Protection.php
@@ -1,11 +1,11 @@
 <?php
-use PhpOffice\PhpWord\SimpleType\DocProtect;
+use Shareforce\PhpWord\SimpleType\DocProtect;
 
 include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s') , ' Create new PhpWord object' , EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 $documentProtection = $phpWord->getSettings()->getDocumentProtection();
 $documentProtection->setEditing(DocProtect::READ_ONLY);

--- a/samples/Sample_39_TrackChanges.php
+++ b/samples/Sample_39_TrackChanges.php
@@ -1,11 +1,11 @@
 <?php
-use PhpOffice\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\Element\TrackChange;
 
 include_once 'Sample_Header.php';
 
 // New Word Document
 echo date('H:i:s') , ' Create new PhpWord object' , EOL;
-$phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord = new \Shareforce\PhpWord\PhpWord();
 
 // New portrait section
 $section = $phpWord->addSection();

--- a/samples/Sample_40_TemplateSetComplexValue.php
+++ b/samples/Sample_40_TemplateSetComplexValue.php
@@ -1,14 +1,14 @@
 <?php
-use PhpOffice\PhpWord\Element\Field;
-use PhpOffice\PhpWord\Element\Table;
-use PhpOffice\PhpWord\Element\TextRun;
-use PhpOffice\PhpWord\SimpleType\TblWidth;
+use Shareforce\PhpWord\Element\Field;
+use Shareforce\PhpWord\Element\Table;
+use Shareforce\PhpWord\Element\TextRun;
+use Shareforce\PhpWord\SimpleType\TblWidth;
 
 include_once 'Sample_Header.php';
 
 // Template processor instance creation
 echo date('H:i:s'), ' Creating new TemplateProcessor instance...', EOL;
-$templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor('resources/Sample_40_TemplateSetComplexValue.docx');
+$templateProcessor = new \Shareforce\PhpWord\TemplateProcessor('resources/Sample_40_TemplateSetComplexValue.docx');
 
 $title = new TextRun();
 $title->addText('This title has been set ', array('bold' => true, 'italic' => true, 'color' => 'blue'));

--- a/samples/Sample_41_TemplateSetChart.php
+++ b/samples/Sample_41_TemplateSetChart.php
@@ -1,12 +1,12 @@
 <?php
-use PhpOffice\PhpWord\Element\Chart;
-use PhpOffice\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Element\Chart;
+use Shareforce\PhpWord\Shared\Converter;
 
 include_once 'Sample_Header.php';
 
 // Template processor instance creation
 echo date('H:i:s'), ' Creating new TemplateProcessor instance...', EOL;
-$templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor('resources/Sample_41_TemplateSetChart.docx');
+$templateProcessor = new \Shareforce\PhpWord\TemplateProcessor('resources/Sample_41_TemplateSetChart.docx');
 
 $chartTypes = array('pie', 'doughnut', 'bar', 'column', 'line', 'area', 'scatter', 'radar', 'stacked_bar', 'percent_stacked_bar', 'stacked_column', 'percent_stacked_column');
 $twoSeries = array('bar', 'column', 'line', 'area', 'scatter', 'radar', 'stacked_bar', 'percent_stacked_bar', 'stacked_column', 'percent_stacked_column');

--- a/samples/Sample_Header.php
+++ b/samples/Sample_Header.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../bootstrap.php';
 
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Settings;
 
 date_default_timezone_set('UTC');
 error_reporting(E_ALL);
@@ -61,7 +61,7 @@ if ($handle = opendir('.')) {
 /**
  * Write documents
  *
- * @param \PhpOffice\PhpWord\PhpWord $phpWord
+ * @param \Shareforce\PhpWord\PhpWord $phpWord
  * @param string $filename
  * @param array $writers
  *

--- a/samples/index.php
+++ b/samples/index.php
@@ -1,7 +1,7 @@
 <?php
 include_once 'Sample_Header.php';
 
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Settings;
 
 $requirements = array(
     'php'   => array('PHP 5.3.3', version_compare(PHP_VERSION, '5.3.3', '>=')),

--- a/src/PhpWord/Collection/AbstractCollection.php
+++ b/src/PhpWord/Collection/AbstractCollection.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
 /**
  * Collection abstract class
@@ -27,14 +27,14 @@ abstract class AbstractCollection
     /**
      * Items
      *
-     * @var \PhpOffice\PhpWord\Element\AbstractContainer[]
+     * @var \Shareforce\PhpWord\Element\AbstractContainer[]
      */
     private $items = array();
 
     /**
      * Get items
      *
-     * @return \PhpOffice\PhpWord\Element\AbstractContainer[]
+     * @return \Shareforce\PhpWord\Element\AbstractContainer[]
      */
     public function getItems()
     {
@@ -45,7 +45,7 @@ abstract class AbstractCollection
      * Get item by index
      *
      * @param int $index
-     * @return \PhpOffice\PhpWord\Element\AbstractContainer
+     * @return \Shareforce\PhpWord\Element\AbstractContainer
      */
     public function getItem($index)
     {
@@ -60,7 +60,7 @@ abstract class AbstractCollection
      * Set item.
      *
      * @param int $index
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $item
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $item
      */
     public function setItem($index, $item)
     {
@@ -72,7 +72,7 @@ abstract class AbstractCollection
     /**
      * Add new item
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $item
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $item
      * @return int
      */
     public function addItem($item)

--- a/src/PhpWord/Collection/Bookmarks.php
+++ b/src/PhpWord/Collection/Bookmarks.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
 /**
  * Bookmarks collection

--- a/src/PhpWord/Collection/Charts.php
+++ b/src/PhpWord/Collection/Charts.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
 /**
  * Charts collection

--- a/src/PhpWord/Collection/Comments.php
+++ b/src/PhpWord/Collection/Comments.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
 /**
  * Comments collection

--- a/src/PhpWord/Collection/Endnotes.php
+++ b/src/PhpWord/Collection/Endnotes.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
 /**
  * Endnotes collection

--- a/src/PhpWord/Collection/Footnotes.php
+++ b/src/PhpWord/Collection/Footnotes.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
 /**
  * Footnotes collection

--- a/src/PhpWord/Collection/Titles.php
+++ b/src/PhpWord/Collection/Titles.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
 /**
  * Titles collection

--- a/src/PhpWord/ComplexType/FootnoteProperties.php
+++ b/src/PhpWord/ComplexType/FootnoteProperties.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\ComplexType;
+namespace Shareforce\PhpWord\ComplexType;
 
-use PhpOffice\PhpWord\SimpleType\NumberFormat;
+use Shareforce\PhpWord\SimpleType\NumberFormat;
 
 /**
  * Footnote properties
@@ -43,7 +43,7 @@ final class FootnoteProperties
     private $pos;
 
     /**
-     * Footnote Numbering Format w:numFmt, one of PhpOffice\PhpWord\SimpleType\NumberFormat
+     * Footnote Numbering Format w:numFmt, one of Shareforce\PhpWord\SimpleType\NumberFormat
      *
      * @var string
      */

--- a/src/PhpWord/ComplexType/ProofState.php
+++ b/src/PhpWord/ComplexType/ProofState.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\ComplexType;
+namespace Shareforce\PhpWord\ComplexType;
 
 /**
  * Spelling and Grammatical Checking State

--- a/src/PhpWord/ComplexType/TblWidth.php
+++ b/src/PhpWord/ComplexType/TblWidth.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\ComplexType;
+namespace Shareforce\PhpWord\ComplexType;
 
-use PhpOffice\PhpWord\SimpleType\TblWidth as TblWidthSimpleType;
+use Shareforce\PhpWord\SimpleType\TblWidth as TblWidthSimpleType;
 
 /**
  * @see http://www.datypic.com/sc/ooxml/t-w_CT_TblWidth.html

--- a/src/PhpWord/ComplexType/TrackChangesView.php
+++ b/src/PhpWord/ComplexType/TrackChangesView.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\ComplexType;
+namespace Shareforce\PhpWord\ComplexType;
 
 /**
  * Visibility of Annotation Types

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Container abstract class
@@ -45,7 +45,7 @@ namespace PhpOffice\PhpWord\Element;
  * @method FormField addFormField(string $type, mixed $fStyle = null, mixed $pStyle = null)
  * @method SDT addSDT(string $type)
  *
- * @method \PhpOffice\PhpWord\Element\OLEObject addObject(string $source, mixed $style = null) deprecated, use addOLEObject instead
+ * @method \Shareforce\PhpWord\Element\OLEObject addObject(string $source, mixed $style = null) deprecated, use addOLEObject instead
  *
  * @since 0.10.0
  */
@@ -54,7 +54,7 @@ abstract class AbstractContainer extends AbstractElement
     /**
      * Elements collection
      *
-     * @var \PhpOffice\PhpWord\Element\AbstractElement[]
+     * @var \Shareforce\PhpWord\Element\AbstractElement[]
      */
     protected $elements = array();
 
@@ -75,7 +75,7 @@ abstract class AbstractContainer extends AbstractElement
      *
      * @param mixed $function
      * @param mixed $args
-     * @return \PhpOffice\PhpWord\Element\AbstractElement
+     * @return \Shareforce\PhpWord\Element\AbstractElement
      */
     public function __call($function, $args)
     {
@@ -123,7 +123,7 @@ abstract class AbstractContainer extends AbstractElement
      * Each element has different number of parameters passed
      *
      * @param string $elementName
-     * @return \PhpOffice\PhpWord\Element\AbstractElement
+     * @return \Shareforce\PhpWord\Element\AbstractElement
      */
     protected function addElement($elementName)
     {
@@ -142,7 +142,7 @@ abstract class AbstractContainer extends AbstractElement
         $elementArgs = $args;
         array_shift($elementArgs); // Shift the $elementName off the beginning of array
 
-        /** @var \PhpOffice\PhpWord\Element\AbstractElement $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\AbstractElement $element Type hint */
         $element = $reflection->newInstanceArgs($elementArgs);
 
         // Set parent container
@@ -158,7 +158,7 @@ abstract class AbstractContainer extends AbstractElement
     /**
      * Get all elements
      *
-     * @return \PhpOffice\PhpWord\Element\AbstractElement[]
+     * @return \Shareforce\PhpWord\Element\AbstractElement[]
      */
     public function getElements()
     {
@@ -169,7 +169,7 @@ abstract class AbstractContainer extends AbstractElement
      * Returns the element at the requested position
      *
      * @param int $index
-     * @return \PhpOffice\PhpWord\Element\AbstractElement|null
+     * @return \Shareforce\PhpWord\Element\AbstractElement|null
      */
     public function getElement($index)
     {
@@ -183,13 +183,13 @@ abstract class AbstractContainer extends AbstractElement
     /**
      * Removes the element at requested index
      *
-     * @param int|\PhpOffice\PhpWord\Element\AbstractElement $toRemove
+     * @param int|\Shareforce\PhpWord\Element\AbstractElement $toRemove
      */
     public function removeElement($toRemove)
     {
         if (is_int($toRemove) && array_key_exists($toRemove, $this->elements)) {
             unset($this->elements[$toRemove]);
-        } elseif ($toRemove instanceof \PhpOffice\PhpWord\Element\AbstractElement) {
+        } elseif ($toRemove instanceof \Shareforce\PhpWord\Element\AbstractElement) {
             foreach ($this->elements as $key => $element) {
                 if ($element->getElementId() === $toRemove->getElementId()) {
                     unset($this->elements[$key]);
@@ -289,7 +289,7 @@ abstract class AbstractContainer extends AbstractElement
      *
      * @param mixed $paragraphStyle
      *
-     * @return \PhpOffice\PhpWord\Element\TextRun
+     * @return \Shareforce\PhpWord\Element\TextRun
      *
      * @codeCoverageIgnore
      */
@@ -305,7 +305,7 @@ abstract class AbstractContainer extends AbstractElement
      *
      * @param mixed $paragraphStyle
      *
-     * @return \PhpOffice\PhpWord\Element\Footnote
+     * @return \Shareforce\PhpWord\Element\Footnote
      *
      * @codeCoverageIgnore
      */

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Media;
-use PhpOffice\PhpWord\PhpWord;
+use Shareforce\PhpWord\Media;
+use Shareforce\PhpWord\PhpWord;
 
 /**
  * Element abstract class
@@ -30,7 +30,7 @@ abstract class AbstractElement
     /**
      * PhpWord object
      *
-     * @var \PhpOffice\PhpWord\PhpWord
+     * @var \Shareforce\PhpWord\PhpWord
      */
     protected $phpWord;
 
@@ -145,7 +145,7 @@ abstract class AbstractElement
     /**
      * Get PhpWord
      *
-     * @return \PhpOffice\PhpWord\PhpWord
+     * @return \Shareforce\PhpWord\PhpWord
      */
     public function getPhpWord()
     {
@@ -155,7 +155,7 @@ abstract class AbstractElement
     /**
      * Set PhpWord as reference.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function setPhpWord(PhpWord $phpWord = null)
     {
@@ -350,7 +350,7 @@ abstract class AbstractElement
      *
      * Passed parameter should be a container, except for Table (contain Row) and Row (contain Cell)
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $container
+     * @param \Shareforce\PhpWord\Element\AbstractElement $container
      */
     public function setParentContainer(self $container)
     {

--- a/src/PhpWord/Element/Bookmark.php
+++ b/src/PhpWord/Element/Bookmark.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Shared\Text as SharedText;
 
 /**
  * Bookmark element

--- a/src/PhpWord/Element/Cell.php
+++ b/src/PhpWord/Element/Cell.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Cell as CellStyle;
+use Shareforce\PhpWord\Style\Cell as CellStyle;
 
 /**
  * Table cell element
@@ -39,7 +39,7 @@ class Cell extends AbstractContainer
     /**
      * Cell style
      *
-     * @var \PhpOffice\PhpWord\Style\Cell
+     * @var \Shareforce\PhpWord\Style\Cell
      */
     private $style;
 
@@ -47,7 +47,7 @@ class Cell extends AbstractContainer
      * Create new instance
      *
      * @param int $width
-     * @param array|\PhpOffice\PhpWord\Style\Cell $style
+     * @param array|\Shareforce\PhpWord\Style\Cell $style
      */
     public function __construct($width = null, $style = null)
     {
@@ -58,7 +58,7 @@ class Cell extends AbstractContainer
     /**
      * Get cell style
      *
-     * @return \PhpOffice\PhpWord\Style\Cell
+     * @return \Shareforce\PhpWord\Style\Cell
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/Chart.php
+++ b/src/PhpWord/Element/Chart.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Chart as ChartStyle;
+use Shareforce\PhpWord\Style\Chart as ChartStyle;
 
 /**
  * Chart element
@@ -50,7 +50,7 @@ class Chart extends AbstractElement
     /**
      * Chart style
      *
-     * @var \PhpOffice\PhpWord\Style\Chart
+     * @var \Shareforce\PhpWord\Style\Chart
      */
     private $style;
 
@@ -120,7 +120,7 @@ class Chart extends AbstractElement
     /**
      * Get chart style
      *
-     * @return \PhpOffice\PhpWord\Style\Chart
+     * @return \Shareforce\PhpWord\Style\Chart
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/CheckBox.php
+++ b/src/PhpWord/Element/CheckBox.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Shared\Text as SharedText;
 
 /**
  * Check box element

--- a/src/PhpWord/Element/Comment.php
+++ b/src/PhpWord/Element/Comment.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Comment element
@@ -77,7 +77,7 @@ class Comment extends TrackChange
     /**
      * Sets the element where this comment starts
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $value
+     * @param \Shareforce\PhpWord\Element\AbstractElement $value
      */
     public function setStartElement(AbstractElement $value)
     {
@@ -90,7 +90,7 @@ class Comment extends TrackChange
     /**
      * Get the element where this comment starts
      *
-     * @return \PhpOffice\PhpWord\Element\AbstractElement
+     * @return \Shareforce\PhpWord\Element\AbstractElement
      */
     public function getStartElement()
     {
@@ -100,7 +100,7 @@ class Comment extends TrackChange
     /**
      * Sets the element where this comment ends
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $value
+     * @param \Shareforce\PhpWord\Element\AbstractElement $value
      */
     public function setEndElement(AbstractElement $value)
     {
@@ -113,7 +113,7 @@ class Comment extends TrackChange
     /**
      * Get the element where this comment ends
      *
-     * @return \PhpOffice\PhpWord\Element\AbstractElement
+     * @return \Shareforce\PhpWord\Element\AbstractElement
      */
     public function getEndElement()
     {

--- a/src/PhpWord/Element/Endnote.php
+++ b/src/PhpWord/Element/Endnote.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Endnote element
@@ -32,7 +32,7 @@ class Endnote extends Footnote
     /**
      * Create new instance
      *
-     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $paragraphStyle
+     * @param string|array|\Shareforce\PhpWord\Style\Paragraph $paragraphStyle
      */
     public function __construct($paragraphStyle = null)
     {

--- a/src/PhpWord/Element/Field.php
+++ b/src/PhpWord/Element/Field.php
@@ -84,6 +84,10 @@ class Field extends AbstractElement
             'properties' => array('StyleIdentifier' => ''),
             'options'    => array('PreserveFormat'),
         ),
+        'REF' => array(
+            'properties' => array('name' => ''),
+            'options'    => array('f', 'h', 'n', 'p', 'r', 't', 'w'),
+        ),
     );
 
     /**

--- a/src/PhpWord/Element/Field.php
+++ b/src/PhpWord/Element/Field.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Font;
 
 /**
  * Field element
@@ -121,15 +121,15 @@ class Field extends AbstractElement
     /**
      * Font style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Font
+     * @var string|\Shareforce\PhpWord\Style\Font
      */
     protected $fontStyle;
 
     /**
      * Set Font style
      *
-     * @param string|array|\PhpOffice\PhpWord\Style\Font $style
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @param string|array|\Shareforce\PhpWord\Style\Font $style
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function setFontStyle($style = null)
     {
@@ -150,7 +150,7 @@ class Field extends AbstractElement
     /**
      * Get Font style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function getFontStyle()
     {
@@ -164,7 +164,7 @@ class Field extends AbstractElement
      * @param array $properties
      * @param array $options
      * @param TextRun|string|null $text
-     * @param string|array|\PhpOffice\PhpWord\Style\Font $fontStyle
+     * @param string|array|\Shareforce\PhpWord\Style\Font $fontStyle
      */
     public function __construct($type = null, $properties = array(), $options = array(), $text = null, $fontStyle = null)
     {

--- a/src/PhpWord/Element/Footer.php
+++ b/src/PhpWord/Element/Footer.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Footer element

--- a/src/PhpWord/Element/Footnote.php
+++ b/src/PhpWord/Element/Footnote.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Style\Paragraph;
 
 class Footnote extends AbstractContainer
 {
@@ -29,7 +29,7 @@ class Footnote extends AbstractContainer
     /**
      * Paragraph style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Paragraph
+     * @var string|\Shareforce\PhpWord\Style\Paragraph
      */
     protected $paragraphStyle;
 
@@ -43,7 +43,7 @@ class Footnote extends AbstractContainer
     /**
      * Create new instance
      *
-     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $paragraphStyle
+     * @param string|array|\Shareforce\PhpWord\Style\Paragraph $paragraphStyle
      */
     public function __construct($paragraphStyle = null)
     {
@@ -54,7 +54,7 @@ class Footnote extends AbstractContainer
     /**
      * Get paragraph style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function getParagraphStyle()
     {

--- a/src/PhpWord/Element/FormField.php
+++ b/src/PhpWord/Element/FormField.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Form field element

--- a/src/PhpWord/Element/Header.php
+++ b/src/PhpWord/Element/Header.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Header element

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Exception\CreateTemporaryFileException;
-use PhpOffice\PhpWord\Exception\InvalidImageException;
-use PhpOffice\PhpWord\Exception\UnsupportedImageTypeException;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\ZipArchive;
-use PhpOffice\PhpWord\Style\Image as ImageStyle;
+use Shareforce\PhpWord\Exception\CreateTemporaryFileException;
+use Shareforce\PhpWord\Exception\InvalidImageException;
+use Shareforce\PhpWord\Exception\UnsupportedImageTypeException;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\ZipArchive;
+use Shareforce\PhpWord\Style\Image as ImageStyle;
 
 /**
  * Image element
@@ -136,8 +136,8 @@ class Image extends AbstractElement
      * @param bool $watermark
      * @param string $name
      *
-     * @throws \PhpOffice\PhpWord\Exception\InvalidImageException
-     * @throws \PhpOffice\PhpWord\Exception\UnsupportedImageTypeException
+     * @throws \Shareforce\PhpWord\Exception\InvalidImageException
+     * @throws \Shareforce\PhpWord\Exception\UnsupportedImageTypeException
      */
     public function __construct($source, $style = null, $watermark = false, $name = null)
     {
@@ -399,8 +399,8 @@ class Image extends AbstractElement
     /**
      * Check memory image, supported type, image functions, and proportional width/height.
      *
-     * @throws \PhpOffice\PhpWord\Exception\InvalidImageException
-     * @throws \PhpOffice\PhpWord\Exception\UnsupportedImageTypeException
+     * @throws \Shareforce\PhpWord\Exception\InvalidImageException
+     * @throws \Shareforce\PhpWord\Exception\UnsupportedImageTypeException
      */
     private function checkImage()
     {
@@ -470,7 +470,7 @@ class Image extends AbstractElement
      *
      * @param string $source
      *
-     * @throws \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
+     * @throws \Shareforce\PhpWord\Exception\CreateTemporaryFileException
      *
      * @return array|null
      */

--- a/src/PhpWord/Element/Line.php
+++ b/src/PhpWord/Element/Line.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Line as LineStyle;
+use Shareforce\PhpWord\Style\Line as LineStyle;
 
 /**
  * Line element
@@ -27,7 +27,7 @@ class Line extends AbstractElement
     /**
      * Line style
      *
-     * @var \PhpOffice\PhpWord\Style\Line
+     * @var \Shareforce\PhpWord\Style\Line
      */
     private $style;
 
@@ -44,7 +44,7 @@ class Line extends AbstractElement
     /**
      * Get line style
      *
-     * @return \PhpOffice\PhpWord\Style\Line
+     * @return \Shareforce\PhpWord\Style\Line
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/Link.php
+++ b/src/PhpWord/Element/Link.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Shared\Text as SharedText;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
  * Link element
@@ -43,14 +43,14 @@ class Link extends AbstractElement
     /**
      * Font style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Font
+     * @var string|\Shareforce\PhpWord\Style\Font
      */
     private $fontStyle;
 
     /**
      * Paragraph style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Paragraph
+     * @var string|\Shareforce\PhpWord\Style\Paragraph
      */
     private $paragraphStyle;
 
@@ -109,7 +109,7 @@ class Link extends AbstractElement
     /**
      * Get Text style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function getFontStyle()
     {
@@ -119,7 +119,7 @@ class Link extends AbstractElement
     /**
      * Get Paragraph style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function getParagraphStyle()
     {

--- a/src/PhpWord/Element/ListItem.php
+++ b/src/PhpWord/Element/ListItem.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Shared\Text as SharedText;
-use PhpOffice\PhpWord\Style\ListItem as ListItemStyle;
+use Shareforce\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Style\ListItem as ListItemStyle;
 
 /**
  * List item element
@@ -28,14 +28,14 @@ class ListItem extends AbstractElement
     /**
      * Element style
      *
-     * @var \PhpOffice\PhpWord\Style\ListItem
+     * @var \Shareforce\PhpWord\Style\ListItem
      */
     private $style;
 
     /**
      * Text object
      *
-     * @var \PhpOffice\PhpWord\Element\Text
+     * @var \Shareforce\PhpWord\Element\Text
      */
     private $textObject;
 
@@ -71,7 +71,7 @@ class ListItem extends AbstractElement
     /**
      * Get style
      *
-     * @return \PhpOffice\PhpWord\Style\ListItem
+     * @return \Shareforce\PhpWord\Style\ListItem
      */
     public function getStyle()
     {
@@ -81,7 +81,7 @@ class ListItem extends AbstractElement
     /**
      * Get Text object
      *
-     * @return \PhpOffice\PhpWord\Element\Text
+     * @return \Shareforce\PhpWord\Element\Text
      */
     public function getTextObject()
     {

--- a/src/PhpWord/Element/ListItemRun.php
+++ b/src/PhpWord/Element/ListItemRun.php
@@ -15,9 +15,9 @@
 * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
 */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\ListItem as ListItemStyle;
+use Shareforce\PhpWord\Style\ListItem as ListItemStyle;
 
 /**
  * List item element
@@ -32,7 +32,7 @@ class ListItemRun extends TextRun
     /**
      * ListItem Style
      *
-     * @var \PhpOffice\PhpWord\Style\ListItem
+     * @var \Shareforce\PhpWord\Style\ListItem
      */
     private $style;
 
@@ -66,7 +66,7 @@ class ListItemRun extends TextRun
     /**
      * Get ListItem style.
      *
-     * @return \PhpOffice\PhpWord\Style\ListItem
+     * @return \Shareforce\PhpWord\Style\ListItem
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/OLEObject.php
+++ b/src/PhpWord/Element/OLEObject.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Exception\InvalidObjectException;
-use PhpOffice\PhpWord\Style\Image as ImageStyle;
+use Shareforce\PhpWord\Exception\InvalidObjectException;
+use Shareforce\PhpWord\Style\Image as ImageStyle;
 
 /**
  * OLEObject element
@@ -35,7 +35,7 @@ class OLEObject extends AbstractElement
     /**
      * Image Style
      *
-     * @var \PhpOffice\PhpWord\Style\Image
+     * @var \Shareforce\PhpWord\Style\Image
      */
     private $style;
 
@@ -66,7 +66,7 @@ class OLEObject extends AbstractElement
      * @param string $source
      * @param mixed $style
      *
-     * @throws \PhpOffice\PhpWord\Exception\InvalidObjectException
+     * @throws \Shareforce\PhpWord\Exception\InvalidObjectException
      */
     public function __construct($source, $style = null)
     {
@@ -102,7 +102,7 @@ class OLEObject extends AbstractElement
     /**
      * Get object style
      *
-     * @return \PhpOffice\PhpWord\Style\Image
+     * @return \Shareforce\PhpWord\Style\Image
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/PageBreak.php
+++ b/src/PhpWord/Element/PageBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Page break element

--- a/src/PhpWord/Element/PreserveText.php
+++ b/src/PhpWord/Element/PreserveText.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Shared\Text as SharedText;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
  * Preserve text/field element
@@ -36,14 +36,14 @@ class PreserveText extends AbstractElement
     /**
      * Text style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Font
+     * @var string|\Shareforce\PhpWord\Style\Font
      */
     private $fontStyle;
 
     /**
      * Paragraph style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Paragraph
+     * @var string|\Shareforce\PhpWord\Style\Paragraph
      */
     private $paragraphStyle;
 
@@ -69,7 +69,7 @@ class PreserveText extends AbstractElement
     /**
      * Get Text style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function getFontStyle()
     {
@@ -79,7 +79,7 @@ class PreserveText extends AbstractElement
     /**
      * Get Paragraph style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function getParagraphStyle()
     {

--- a/src/PhpWord/Element/Row.php
+++ b/src/PhpWord/Element/Row.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Row as RowStyle;
+use Shareforce\PhpWord\Style\Row as RowStyle;
 
 /**
  * Table row element
@@ -36,14 +36,14 @@ class Row extends AbstractElement
     /**
      * Row style
      *
-     * @var \PhpOffice\PhpWord\Style\Row
+     * @var \Shareforce\PhpWord\Style\Row
      */
     private $style;
 
     /**
      * Row cells
      *
-     * @var \PhpOffice\PhpWord\Element\Cell[]
+     * @var \Shareforce\PhpWord\Element\Cell[]
      */
     private $cells = array();
 
@@ -64,7 +64,7 @@ class Row extends AbstractElement
      *
      * @param int $width
      * @param mixed $style
-     * @return \PhpOffice\PhpWord\Element\Cell
+     * @return \Shareforce\PhpWord\Element\Cell
      */
     public function addCell($width = null, $style = null)
     {
@@ -78,7 +78,7 @@ class Row extends AbstractElement
     /**
      * Get all cells
      *
-     * @return \PhpOffice\PhpWord\Element\Cell[]
+     * @return \Shareforce\PhpWord\Element\Cell[]
      */
     public function getCells()
     {
@@ -88,7 +88,7 @@ class Row extends AbstractElement
     /**
      * Get row style
      *
-     * @return \PhpOffice\PhpWord\Style\Row
+     * @return \Shareforce\PhpWord\Style\Row
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/SDT.php
+++ b/src/PhpWord/Element/SDT.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * Structured document tag (SDT) element

--- a/src/PhpWord/Element/Section.php
+++ b/src/PhpWord/Element/Section.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\ComplexType\FootnoteProperties;
-use PhpOffice\PhpWord\Style\Section as SectionStyle;
+use Shareforce\PhpWord\ComplexType\FootnoteProperties;
+use Shareforce\PhpWord\Style\Section as SectionStyle;
 
 class Section extends AbstractContainer
 {
@@ -30,7 +30,7 @@ class Section extends AbstractContainer
     /**
      * Section style
      *
-     * @var \PhpOffice\PhpWord\Style\Section
+     * @var \Shareforce\PhpWord\Style\Section
      */
     private $style;
 
@@ -59,7 +59,7 @@ class Section extends AbstractContainer
      * Create new instance
      *
      * @param int $sectionCount
-     * @param null|array|\PhpOffice\PhpWord\Style $style
+     * @param null|array|\Shareforce\PhpWord\Style $style
      */
     public function __construct($sectionCount, $style = null)
     {
@@ -86,7 +86,7 @@ class Section extends AbstractContainer
     /**
      * Get section style
      *
-     * @return \PhpOffice\PhpWord\Style\Section
+     * @return \Shareforce\PhpWord\Style\Section
      */
     public function getStyle()
     {
@@ -220,7 +220,7 @@ class Section extends AbstractContainer
 
         if (in_array($type, array(Header::AUTO, Header::FIRST, Header::EVEN))) {
             $index = count($collection);
-            /** @var \PhpOffice\PhpWord\Element\AbstractContainer $container Type hint */
+            /** @var \Shareforce\PhpWord\Element\AbstractContainer $container Type hint */
             $container = new $containerClass($this->sectionId, ++$index, $type);
             $container->setPhpWord($this->phpWord);
 
@@ -250,7 +250,7 @@ class Section extends AbstractContainer
      *
      * @deprecated 0.12.0
      *
-     * @return \PhpOffice\PhpWord\Style\Section
+     * @return \Shareforce\PhpWord\Style\Section
      *
      * @codeCoverageIgnore
      */

--- a/src/PhpWord/Element/Shape.php
+++ b/src/PhpWord/Element/Shape.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Shape as ShapeStyle;
+use Shareforce\PhpWord\Style\Shape as ShapeStyle;
 
 /**
  * Shape element
@@ -36,7 +36,7 @@ class Shape extends AbstractElement
     /**
      * Shape style
      *
-     * @var \PhpOffice\PhpWord\Style\Shape
+     * @var \Shareforce\PhpWord\Style\Shape
      */
     private $style;
 
@@ -79,7 +79,7 @@ class Shape extends AbstractElement
     /**
      * Get shape style
      *
-     * @return \PhpOffice\PhpWord\Style\Shape
+     * @return \Shareforce\PhpWord\Style\Shape
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/TOC.php
+++ b/src/PhpWord/Element/TOC.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\TOC as TOCStyle;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\TOC as TOCStyle;
 
 /**
  * Table of contents
@@ -29,14 +29,14 @@ class TOC extends AbstractElement
     /**
      * TOC style
      *
-     * @var \PhpOffice\PhpWord\Style\TOC
+     * @var \Shareforce\PhpWord\Style\TOC
      */
     private $TOCStyle;
 
     /**
      * Font style
      *
-     * @var \PhpOffice\PhpWord\Style\Font|string
+     * @var \Shareforce\PhpWord\Style\Font|string
      */
     private $fontStyle;
 
@@ -94,7 +94,7 @@ class TOC extends AbstractElement
 
         $titles = $this->phpWord->getTitles()->getItems();
         foreach ($titles as $i => $title) {
-            /** @var \PhpOffice\PhpWord\Element\Title $title Type hint */
+            /** @var \Shareforce\PhpWord\Element\Title $title Type hint */
             $depth = $title->getDepth();
             if ($this->minDepth > $depth) {
                 unset($titles[$i]);
@@ -110,7 +110,7 @@ class TOC extends AbstractElement
     /**
      * Get TOC Style
      *
-     * @return \PhpOffice\PhpWord\Style\TOC
+     * @return \Shareforce\PhpWord\Style\TOC
      */
     public function getStyleTOC()
     {
@@ -120,7 +120,7 @@ class TOC extends AbstractElement
     /**
      * Get Font Style
      *
-     * @return \PhpOffice\PhpWord\Style\Font|string
+     * @return \Shareforce\PhpWord\Style\Font|string
      */
     public function getStyleFont()
     {

--- a/src/PhpWord/Element/Table.php
+++ b/src/PhpWord/Element/Table.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Table as TableStyle;
+use Shareforce\PhpWord\Style\Table as TableStyle;
 
 /**
  * Table element
@@ -27,14 +27,14 @@ class Table extends AbstractElement
     /**
      * Table style
      *
-     * @var \PhpOffice\PhpWord\Style\Table
+     * @var \Shareforce\PhpWord\Style\Table
      */
     private $style;
 
     /**
      * Table rows
      *
-     * @var \PhpOffice\PhpWord\Element\Row[]
+     * @var \Shareforce\PhpWord\Element\Row[]
      */
     private $rows = array();
 
@@ -60,7 +60,7 @@ class Table extends AbstractElement
      *
      * @param int $height
      * @param mixed $style
-     * @return \PhpOffice\PhpWord\Element\Row
+     * @return \Shareforce\PhpWord\Element\Row
      */
     public function addRow($height = null, $style = null)
     {
@@ -76,7 +76,7 @@ class Table extends AbstractElement
      *
      * @param int $width
      * @param mixed $style
-     * @return \PhpOffice\PhpWord\Element\Cell
+     * @return \Shareforce\PhpWord\Element\Cell
      */
     public function addCell($width = null, $style = null)
     {
@@ -90,7 +90,7 @@ class Table extends AbstractElement
     /**
      * Get all rows
      *
-     * @return \PhpOffice\PhpWord\Element\Row[]
+     * @return \Shareforce\PhpWord\Element\Row[]
      */
     public function getRows()
     {
@@ -100,7 +100,7 @@ class Table extends AbstractElement
     /**
      * Get table style
      *
-     * @return \PhpOffice\PhpWord\Style\Table
+     * @return \Shareforce\PhpWord\Style\Table
      */
     public function getStyle()
     {
@@ -138,7 +138,7 @@ class Table extends AbstractElement
 
         $rowCount = count($this->rows);
         for ($i = 0; $i < $rowCount; $i++) {
-            /** @var \PhpOffice\PhpWord\Element\Row $row Type hint */
+            /** @var \Shareforce\PhpWord\Element\Row $row Type hint */
             $row = $this->rows[$i];
             $cellCount = count($row->getCells());
             if ($columnCount < $cellCount) {

--- a/src/PhpWord/Element/Text.php
+++ b/src/PhpWord/Element/Text.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Shared\Text as SharedText;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
  * Text element
@@ -36,14 +36,14 @@ class Text extends AbstractElement
     /**
      * Text style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Font
+     * @var string|\Shareforce\PhpWord\Style\Font
      */
     protected $fontStyle;
 
     /**
      * Paragraph style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Paragraph
+     * @var string|\Shareforce\PhpWord\Style\Paragraph
      */
     protected $paragraphStyle;
 
@@ -64,9 +64,9 @@ class Text extends AbstractElement
     /**
      * Set Text style
      *
-     * @param string|array|\PhpOffice\PhpWord\Style\Font $style
-     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $paragraphStyle
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @param string|array|\Shareforce\PhpWord\Style\Font $style
+     * @param string|array|\Shareforce\PhpWord\Style\Paragraph $paragraphStyle
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function setFontStyle($style = null, $paragraphStyle = null)
     {
@@ -89,7 +89,7 @@ class Text extends AbstractElement
     /**
      * Get Text style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function getFontStyle()
     {
@@ -99,8 +99,8 @@ class Text extends AbstractElement
     /**
      * Set Paragraph style
      *
-     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $style
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @param string|array|\Shareforce\PhpWord\Style\Paragraph $style
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function setParagraphStyle($style = null)
     {
@@ -121,7 +121,7 @@ class Text extends AbstractElement
     /**
      * Get Paragraph style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function getParagraphStyle()
     {

--- a/src/PhpWord/Element/TextBox.php
+++ b/src/PhpWord/Element/TextBox.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\TextBox as TextBoxStyle;
+use Shareforce\PhpWord\Style\TextBox as TextBoxStyle;
 
 /**
  * TextBox element
@@ -34,7 +34,7 @@ class TextBox extends AbstractContainer
     /**
      * TextBox style
      *
-     * @var \PhpOffice\PhpWord\Style\TextBox
+     * @var \Shareforce\PhpWord\Style\TextBox
      */
     private $style;
 
@@ -51,7 +51,7 @@ class TextBox extends AbstractContainer
     /**
      * Get textbox style
      *
-     * @return \PhpOffice\PhpWord\Style\TextBox
+     * @return \Shareforce\PhpWord\Style\TextBox
      */
     public function getStyle()
     {

--- a/src/PhpWord/Element/TextBreak.php
+++ b/src/PhpWord/Element/TextBreak.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
  * Text break element
@@ -28,14 +28,14 @@ class TextBreak extends AbstractElement
     /**
      * Paragraph style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Paragraph
+     * @var string|\Shareforce\PhpWord\Style\Paragraph
      */
     private $paragraphStyle = null;
 
     /**
      * Text style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Font
+     * @var string|\Shareforce\PhpWord\Style\Font
      */
     private $fontStyle = null;
 
@@ -60,7 +60,7 @@ class TextBreak extends AbstractElement
      *
      * @param mixed $style
      * @param mixed $paragraphStyle
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function setFontStyle($style = null, $paragraphStyle = null)
     {
@@ -81,7 +81,7 @@ class TextBreak extends AbstractElement
     /**
      * Get Text style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Font
+     * @return string|\Shareforce\PhpWord\Style\Font
      */
     public function getFontStyle()
     {
@@ -91,8 +91,8 @@ class TextBreak extends AbstractElement
     /**
      * Set Paragraph style
      *
-     * @param   string|array|\PhpOffice\PhpWord\Style\Paragraph $style
-     * @return  string|\PhpOffice\PhpWord\Style\Paragraph
+     * @param   string|array|\Shareforce\PhpWord\Style\Paragraph $style
+     * @return  string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function setParagraphStyle($style = null)
     {
@@ -111,7 +111,7 @@ class TextBreak extends AbstractElement
     /**
      * Get Paragraph style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function getParagraphStyle()
     {

--- a/src/PhpWord/Element/TextRun.php
+++ b/src/PhpWord/Element/TextRun.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
  * Textrun/paragraph element
@@ -32,14 +32,14 @@ class TextRun extends AbstractContainer
     /**
      * Paragraph style
      *
-     * @var string|\PhpOffice\PhpWord\Style\Paragraph
+     * @var string|\Shareforce\PhpWord\Style\Paragraph
      */
     protected $paragraphStyle;
 
     /**
      * Create new instance
      *
-     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $paragraphStyle
+     * @param string|array|\Shareforce\PhpWord\Style\Paragraph $paragraphStyle
      */
     public function __construct($paragraphStyle = null)
     {
@@ -49,7 +49,7 @@ class TextRun extends AbstractContainer
     /**
      * Get Paragraph style
      *
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function getParagraphStyle()
     {
@@ -59,8 +59,8 @@ class TextRun extends AbstractContainer
     /**
      * Set Paragraph style
      *
-     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $style
-     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     * @param string|array|\Shareforce\PhpWord\Style\Paragraph $style
+     * @return string|\Shareforce\PhpWord\Style\Paragraph
      */
     public function setParagraphStyle($style = null)
     {

--- a/src/PhpWord/Element/Title.php
+++ b/src/PhpWord/Element/Title.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Shared\Text as SharedText;
-use PhpOffice\PhpWord\Style;
+use Shareforce\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Style;
 
 /**
  * Title element

--- a/src/PhpWord/Element/TrackChange.php
+++ b/src/PhpWord/Element/TrackChange.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
  * TrackChange element
@@ -33,7 +33,7 @@ class TrackChange extends AbstractContainer
     protected $container = 'TrackChange';
 
     /**
-     * The type of change, (insert or delete), not applicable for PhpOffice\PhpWord\Element\Comment
+     * The type of change, (insert or delete), not applicable for Shareforce\PhpWord\Element\Comment
      *
      * @var string
      */

--- a/src/PhpWord/Escaper/AbstractEscaper.php
+++ b/src/PhpWord/Escaper/AbstractEscaper.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Escaper;
+namespace Shareforce\PhpWord\Escaper;
 
 /**
  * @since 0.13.0

--- a/src/PhpWord/Escaper/EscaperInterface.php
+++ b/src/PhpWord/Escaper/EscaperInterface.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Escaper;
+namespace Shareforce\PhpWord\Escaper;
 
 /**
  * @since 0.13.0

--- a/src/PhpWord/Escaper/RegExp.php
+++ b/src/PhpWord/Escaper/RegExp.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Escaper;
+namespace Shareforce\PhpWord\Escaper;
 
 /**
  * @since 0.13.0

--- a/src/PhpWord/Escaper/Rtf.php
+++ b/src/PhpWord/Escaper/Rtf.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Escaper;
+namespace Shareforce\PhpWord\Escaper;
 
 /**
  * @since 0.13.0

--- a/src/PhpWord/Escaper/Xml.php
+++ b/src/PhpWord/Escaper/Xml.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Escaper;
+namespace Shareforce\PhpWord\Escaper;
 
 /**
  * @since 0.13.0

--- a/src/PhpWord/Exception/CopyFileException.php
+++ b/src/PhpWord/Exception/CopyFileException.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
  * @since 0.12.0

--- a/src/PhpWord/Exception/CreateTemporaryFileException.php
+++ b/src/PhpWord/Exception/CreateTemporaryFileException.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
  * @since 0.12.0

--- a/src/PhpWord/Exception/Exception.php
+++ b/src/PhpWord/Exception/Exception.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
  * General exception

--- a/src/PhpWord/Exception/InvalidImageException.php
+++ b/src/PhpWord/Exception/InvalidImageException.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
  * Exception used for when an image is not found

--- a/src/PhpWord/Exception/InvalidObjectException.php
+++ b/src/PhpWord/Exception/InvalidObjectException.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
  * Exception used for when an image is not found

--- a/src/PhpWord/Exception/InvalidStyleException.php
+++ b/src/PhpWord/Exception/InvalidStyleException.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 use InvalidArgumentException;
 

--- a/src/PhpWord/Exception/UnsupportedImageTypeException.php
+++ b/src/PhpWord/Exception/UnsupportedImageTypeException.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
  * Exception used for when an image type is unsupported

--- a/src/PhpWord/IOFactory.php
+++ b/src/PhpWord/IOFactory.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\Reader\ReaderInterface;
-use PhpOffice\PhpWord\Writer\WriterInterface;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Reader\ReaderInterface;
+use Shareforce\PhpWord\Writer\WriterInterface;
 
 abstract class IOFactory
 {
@@ -29,7 +29,7 @@ abstract class IOFactory
      * @param PhpWord $phpWord
      * @param string $name
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return WriterInterface
      */
@@ -39,7 +39,7 @@ abstract class IOFactory
             throw new Exception("\"{$name}\" is not a valid writer.");
         }
 
-        $fqName = "PhpOffice\\PhpWord\\Writer\\{$name}";
+        $fqName = "Shareforce\\PhpWord\\Writer\\{$name}";
 
         return new $fqName($phpWord);
     }
@@ -63,15 +63,15 @@ abstract class IOFactory
      *
      * @param string $type
      * @param string $name
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
-     * @return \PhpOffice\PhpWord\Writer\WriterInterface|\PhpOffice\PhpWord\Reader\ReaderInterface
+     * @return \Shareforce\PhpWord\Writer\WriterInterface|\Shareforce\PhpWord\Reader\ReaderInterface
      */
     private static function createObject($type, $name, $phpWord = null)
     {
-        $class = "PhpOffice\\PhpWord\\{$type}\\{$name}";
+        $class = "Shareforce\\PhpWord\\{$type}\\{$name}";
         if (class_exists($class) && self::isConcreteClass($class)) {
             return new $class($phpWord);
         }
@@ -83,11 +83,11 @@ abstract class IOFactory
      *
      * @param string $filename The name of the file
      * @param string $readerName
-     * @return \PhpOffice\PhpWord\PhpWord $phpWord
+     * @return \Shareforce\PhpWord\PhpWord $phpWord
      */
     public static function load($filename, $readerName = 'Word2007')
     {
-        /** @var \PhpOffice\PhpWord\Reader\ReaderInterface $reader */
+        /** @var \Shareforce\PhpWord\Reader\ReaderInterface $reader */
         $reader = self::createReader($readerName);
 
         return $reader->load($filename);

--- a/src/PhpWord/Media.php
+++ b/src/PhpWord/Media.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Element\Image;
-use PhpOffice\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Element\Image;
+use Shareforce\PhpWord\Exception\Exception;
 
 /**
  * Media collection
@@ -41,9 +41,9 @@ class Media
      * @param string $container section|headerx|footerx|footnote|endnote
      * @param string $mediaType image|object|link
      * @param string $source
-     * @param \PhpOffice\PhpWord\Element\Image $image
+     * @param \Shareforce\PhpWord\Element\Image $image
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return int
      */
@@ -208,7 +208,7 @@ class Media
      *
      * @param  string $src
      * @param  string $type
-     * @param  \PhpOffice\PhpWord\Element\Image $image
+     * @param  \Shareforce\PhpWord\Element\Image $image
      *
      * @return int
      *
@@ -274,7 +274,7 @@ class Media
      *
      * @param  int $headerCount
      * @param  string $src
-     * @param  \PhpOffice\PhpWord\Element\Image $image
+     * @param  \Shareforce\PhpWord\Element\Image $image
      *
      * @return int
      *
@@ -322,7 +322,7 @@ class Media
      *
      * @param  int $footerCount
      * @param  string $src
-     * @param  \PhpOffice\PhpWord\Element\Image $image
+     * @param  \Shareforce\PhpWord\Element\Image $image
      *
      * @return int
      *

--- a/src/PhpWord/Metadata/Compatibility.php
+++ b/src/PhpWord/Metadata/Compatibility.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Metadata;
+namespace Shareforce\PhpWord\Metadata;
 
 /**
  * Compatibility setting class

--- a/src/PhpWord/Metadata/DocInfo.php
+++ b/src/PhpWord/Metadata/DocInfo.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Metadata;
+namespace Shareforce\PhpWord\Metadata;
 
 /**
  * Document information

--- a/src/PhpWord/Metadata/Protection.php
+++ b/src/PhpWord/Metadata/Protection.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Metadata;
+namespace Shareforce\PhpWord\Metadata;
 
-use PhpOffice\PhpWord\Shared\Microsoft\PasswordEncoder;
-use PhpOffice\PhpWord\SimpleType\DocProtect;
+use Shareforce\PhpWord\Shared\Microsoft\PasswordEncoder;
+use Shareforce\PhpWord\SimpleType\DocProtect;
 
 /**
  * Document protection class
@@ -51,7 +51,7 @@ class Protection
     private $spinCount = 100000;
 
     /**
-     * Cryptographic Hashing Algorithm (see constants defined in \PhpOffice\PhpWord\Shared\Microsoft\PasswordEncoder)
+     * Cryptographic Hashing Algorithm (see constants defined in \Shareforce\PhpWord\Shared\Microsoft\PasswordEncoder)
      *
      * @var string
      */
@@ -89,7 +89,7 @@ class Protection
     /**
      * Set editing protection
      *
-     * @param string $editing Any value of \PhpOffice\PhpWord\SimpleType\DocProtect
+     * @param string $editing Any value of \Shareforce\PhpWord\SimpleType\DocProtect
      * @return self
      */
     public function setEditing($editing = null)

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Metadata;
+namespace Shareforce\PhpWord\Metadata;
 
-use PhpOffice\PhpWord\ComplexType\ProofState;
-use PhpOffice\PhpWord\ComplexType\TrackChangesView;
-use PhpOffice\PhpWord\SimpleType\Zoom;
-use PhpOffice\PhpWord\Style\Language;
+use Shareforce\PhpWord\ComplexType\ProofState;
+use Shareforce\PhpWord\ComplexType\TrackChangesView;
+use Shareforce\PhpWord\SimpleType\Zoom;
+use Shareforce\PhpWord\Style\Language;
 
 /**
  * Setting class
@@ -34,7 +34,7 @@ class Settings
      * Magnification Setting
      *
      * @see  http://www.datypic.com/sc/ooxml/e-w_zoom-1.html
-     * @var mixed either integer, in which case it treated as a percent, or one of PhpOffice\PhpWord\SimpleType\Zoom
+     * @var mixed either integer, in which case it treated as a percent, or one of Shareforce\PhpWord\SimpleType\Zoom
      */
     private $zoom = 100;
 
@@ -91,14 +91,14 @@ class Settings
     /**
      * Spelling and Grammatical Checking State
      *
-     * @var \PhpOffice\PhpWord\ComplexType\ProofState
+     * @var \Shareforce\PhpWord\ComplexType\ProofState
      */
     private $proofState;
 
     /**
      * Document Editing Restrictions
      *
-     * @var \PhpOffice\PhpWord\Metadata\Protection
+     * @var \Shareforce\PhpWord\Metadata\Protection
      */
     private $documentProtection;
 
@@ -255,7 +255,7 @@ class Settings
     /**
      * Get the Visibility of Annotation Types
      *
-     * @return \PhpOffice\PhpWord\ComplexType\TrackChangesView
+     * @return \Shareforce\PhpWord\ComplexType\TrackChangesView
      */
     public function getRevisionView()
     {

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
 */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Element\Section;
+use Shareforce\PhpWord\Exception\Exception;
 
 /**
  * PHPWord main class
@@ -68,7 +68,7 @@ class PhpWord
     /**
      * Collection of sections
      *
-     * @var \PhpOffice\PhpWord\Element\Section[]
+     * @var \Shareforce\PhpWord\Element\Section[]
      */
     private $sections = array();
 
@@ -101,14 +101,14 @@ class PhpWord
         // Collection
         $collections = array('Bookmarks', 'Titles', 'Footnotes', 'Endnotes', 'Charts', 'Comments');
         foreach ($collections as $collection) {
-            $class = 'PhpOffice\\PhpWord\\Collection\\' . $collection;
+            $class = 'Shareforce\\PhpWord\\Collection\\' . $collection;
             $this->collections[$collection] = new $class();
         }
 
         // Metadata
         $metadata = array('DocInfo', 'Settings', 'Compatibility');
         foreach ($metadata as $meta) {
-            $class = 'PhpOffice\\PhpWord\\Metadata\\' . $meta;
+            $class = 'Shareforce\\PhpWord\\Metadata\\' . $meta;
             $this->metadata[$meta] = new $class();
         }
     }
@@ -155,7 +155,7 @@ class PhpWord
         if (in_array($function, $addCollection)) {
             $key = ucfirst(str_replace('add', '', $function) . 's');
 
-            /** @var \PhpOffice\PhpWord\Collection\AbstractCollection $collectionObject */
+            /** @var \Shareforce\PhpWord\Collection\AbstractCollection $collectionObject */
             $collectionObject = $this->collections[$key];
 
             return $collectionObject->addItem(isset($args[0]) ? $args[0] : null);
@@ -163,7 +163,7 @@ class PhpWord
 
         // Run add style method
         if (in_array($function, $addStyle)) {
-            return forward_static_call_array(array('PhpOffice\\PhpWord\\Style', $function), $args);
+            return forward_static_call_array(array('Shareforce\\PhpWord\\Style', $function), $args);
         }
 
         // Exception
@@ -173,7 +173,7 @@ class PhpWord
     /**
      * Get document properties object
      *
-     * @return \PhpOffice\PhpWord\Metadata\DocInfo
+     * @return \Shareforce\PhpWord\Metadata\DocInfo
      */
     public function getDocInfo()
     {
@@ -183,7 +183,7 @@ class PhpWord
     /**
      * Get protection
      *
-     * @return \PhpOffice\PhpWord\Metadata\Protection
+     * @return \Shareforce\PhpWord\Metadata\Protection
      * @since 0.12.0
      * @deprecated Get the Document protection from PhpWord->getSettings()->getDocumentProtection();
      * @codeCoverageIgnore
@@ -196,7 +196,7 @@ class PhpWord
     /**
      * Get compatibility
      *
-     * @return \PhpOffice\PhpWord\Metadata\Compatibility
+     * @return \Shareforce\PhpWord\Metadata\Compatibility
      * @since 0.12.0
      */
     public function getCompatibility()
@@ -207,7 +207,7 @@ class PhpWord
     /**
      * Get compatibility
      *
-     * @return \PhpOffice\PhpWord\Metadata\Settings
+     * @return \Shareforce\PhpWord\Metadata\Settings
      * @since 0.14.0
      */
     public function getSettings()
@@ -218,7 +218,7 @@ class PhpWord
     /**
      * Get all sections
      *
-     * @return \PhpOffice\PhpWord\Element\Section[]
+     * @return \Shareforce\PhpWord\Element\Section[]
      */
     public function getSections()
     {
@@ -229,7 +229,7 @@ class PhpWord
      * Returns the section at the requested position
      *
      * @param int $index
-     * @return \PhpOffice\PhpWord\Element\Section|null
+     * @return \Shareforce\PhpWord\Element\Section|null
      */
     public function getSection($index)
     {
@@ -244,7 +244,7 @@ class PhpWord
      * Create new section
      *
      * @param array $style
-     * @return \PhpOffice\PhpWord\Element\Section
+     * @return \Shareforce\PhpWord\Element\Section
      */
     public function addSection($style = null)
     {
@@ -310,7 +310,7 @@ class PhpWord
      * Set default paragraph style definition to styles.xml
      *
      * @param array $styles Paragraph style definition
-     * @return \PhpOffice\PhpWord\Style\Paragraph
+     * @return \Shareforce\PhpWord\Style\Paragraph
      */
     public function setDefaultParagraphStyle($styles)
     {
@@ -324,7 +324,7 @@ class PhpWord
      *
      * @param  string $filename Fully qualified filename
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return TemplateProcessor
      *
@@ -382,7 +382,7 @@ class PhpWord
      *
      * @param array $settings
      *
-     * @return \PhpOffice\PhpWord\Element\Section
+     * @return \Shareforce\PhpWord\Element\Section
      *
      * @codeCoverageIgnore
      */
@@ -396,7 +396,7 @@ class PhpWord
      *
      * @deprecated 0.12.0
      *
-     * @return \PhpOffice\PhpWord\Metadata\DocInfo
+     * @return \Shareforce\PhpWord\Metadata\DocInfo
      *
      * @codeCoverageIgnore
      */
@@ -410,7 +410,7 @@ class PhpWord
      *
      * @deprecated 0.12.0
      *
-     * @param \PhpOffice\PhpWord\Metadata\DocInfo $documentProperties
+     * @param \Shareforce\PhpWord\Metadata\DocInfo $documentProperties
      *
      * @return self
      *

--- a/src/PhpWord/Reader/AbstractReader.php
+++ b/src/PhpWord/Reader/AbstractReader.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Exception\Exception;
 
 /**
  * Reader abstract class
@@ -71,7 +71,7 @@ abstract class AbstractReader implements ReaderInterface
      *
      * @param string $filename
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return resource
      */

--- a/src/PhpWord/Reader/HTML.php
+++ b/src/PhpWord/Reader/HTML.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\Html as HTMLParser;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\Html as HTMLParser;
 
 /**
  * HTML Reader class
@@ -34,7 +34,7 @@ class HTML extends AbstractReader implements ReaderInterface
      *
      * @throws \Exception
      *
-     * @return \PhpOffice\PhpWord\PhpWord
+     * @return \Shareforce\PhpWord\PhpWord
      */
     public function load($docFile)
     {

--- a/src/PhpWord/Reader/MsDoc.php
+++ b/src/PhpWord/Reader/MsDoc.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\Drawing;
-use PhpOffice\PhpWord\Shared\OLERead;
-use PhpOffice\PhpWord\Style;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\Drawing;
+use Shareforce\PhpWord\Shared\OLERead;
+use Shareforce\PhpWord\Style;
 
 /**
  * Reader for Word97

--- a/src/PhpWord/Reader/ODText.php
+++ b/src/PhpWord/Reader/ODText.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Reader for ODText
@@ -31,7 +31,7 @@ class ODText extends AbstractReader implements ReaderInterface
      * Loads PhpWord from file
      *
      * @param string $docFile
-     * @return \PhpOffice\PhpWord\PhpWord
+     * @return \Shareforce\PhpWord\PhpWord
      */
     public function load($docFile)
     {
@@ -53,7 +53,7 @@ class ODText extends AbstractReader implements ReaderInterface
     /**
      * Read document part.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      * @param array $relationships
      * @param string $partName
      * @param string $docFile
@@ -61,9 +61,9 @@ class ODText extends AbstractReader implements ReaderInterface
      */
     private function readPart(PhpWord $phpWord, $relationships, $partName, $docFile, $xmlFile)
     {
-        $partClass = "PhpOffice\\PhpWord\\Reader\\ODText\\{$partName}";
+        $partClass = "Shareforce\\PhpWord\\Reader\\ODText\\{$partName}";
         if (class_exists($partClass)) {
-            /** @var \PhpOffice\PhpWord\Reader\ODText\AbstractPart $part Type hint */
+            /** @var \Shareforce\PhpWord\Reader\ODText\AbstractPart $part Type hint */
             $part = new $partClass($docFile, $xmlFile);
             $part->setRels($relationships);
             $part->read($phpWord);

--- a/src/PhpWord/Reader/ODText/AbstractPart.php
+++ b/src/PhpWord/Reader/ODText/AbstractPart.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\ODText;
+namespace Shareforce\PhpWord\Reader\ODText;
 
-use PhpOffice\PhpWord\Reader\Word2007\AbstractPart as Word2007AbstractPart;
+use Shareforce\PhpWord\Reader\Word2007\AbstractPart as Word2007AbstractPart;
 
 /**
  * Abstract part reader

--- a/src/PhpWord/Reader/ODText/Content.php
+++ b/src/PhpWord/Reader/ODText/Content.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\ODText;
+namespace Shareforce\PhpWord\Reader\ODText;
 
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Content reader
@@ -31,7 +31,7 @@ class Content extends AbstractPart
     /**
      * Read content.xml.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {

--- a/src/PhpWord/Reader/ODText/Meta.php
+++ b/src/PhpWord/Reader/ODText/Meta.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\ODText;
+namespace Shareforce\PhpWord\Reader\ODText;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Meta reader
@@ -30,7 +30,7 @@ class Meta extends AbstractPart
     /**
      * Read meta.xml.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      * @todo Process property type
      */
     public function read(PhpWord $phpWord)

--- a/src/PhpWord/Reader/RTF.php
+++ b/src/PhpWord/Reader/RTF.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Reader\RTF\Document;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Reader\RTF\Document;
 
 /**
  * RTF Reader class
@@ -34,7 +34,7 @@ class RTF extends AbstractReader implements ReaderInterface
      *
      * @throws \Exception
      *
-     * @return \PhpOffice\PhpWord\PhpWord
+     * @return \Shareforce\PhpWord\PhpWord
      */
     public function load($docFile)
     {

--- a/src/PhpWord/Reader/RTF/Document.php
+++ b/src/PhpWord/Reader/RTF/Document.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\RTF;
+namespace Shareforce\PhpWord\Reader\RTF;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
  * RTF document reader
@@ -41,21 +41,21 @@ class Document
     /**
      * PhpWord object
      *
-     * @var \PhpOffice\PhpWord\PhpWord
+     * @var \Shareforce\PhpWord\PhpWord
      */
     private $phpWord;
 
     /**
      * Section object
      *
-     * @var \PhpOffice\PhpWord\Element\Section
+     * @var \Shareforce\PhpWord\Element\Section
      */
     private $section;
 
     /**
      * Textrun object
      *
-     * @var \PhpOffice\PhpWord\Element\TextRun
+     * @var \Shareforce\PhpWord\Element\TextRun
      */
     private $textrun;
 
@@ -130,7 +130,7 @@ class Document
      * - Builds control words and control symbols
      * - Pushes every other character into the text queue
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      * @todo Use `fread` stream for scalability
      */
     public function read(PhpWord $phpWord)

--- a/src/PhpWord/Reader/ReaderInterface.php
+++ b/src/PhpWord/Reader/ReaderInterface.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
 /**
  * Reader interface

--- a/src/PhpWord/Reader/Word2007.php
+++ b/src/PhpWord/Reader/Word2007.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
-use PhpOffice\PhpWord\Shared\ZipArchive;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\Shared\ZipArchive;
 
 /**
  * Reader for Word2007
@@ -34,7 +34,7 @@ class Word2007 extends AbstractReader implements ReaderInterface
      * Loads PhpWord from file
      *
      * @param string $docFile
-     * @return \PhpOffice\PhpWord\PhpWord
+     * @return \Shareforce\PhpWord\PhpWord
      */
     public function load($docFile)
     {
@@ -81,7 +81,7 @@ class Word2007 extends AbstractReader implements ReaderInterface
     /**
      * Read document part.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      * @param array $relationships
      * @param string $partName
      * @param string $docFile
@@ -89,9 +89,9 @@ class Word2007 extends AbstractReader implements ReaderInterface
      */
     private function readPart(PhpWord $phpWord, $relationships, $partName, $docFile, $xmlFile)
     {
-        $partClass = "PhpOffice\\PhpWord\\Reader\\Word2007\\{$partName}";
+        $partClass = "Shareforce\\PhpWord\\Reader\\Word2007\\{$partName}";
         if (class_exists($partClass)) {
-            /** @var \PhpOffice\PhpWord\Reader\Word2007\AbstractPart $part Type hint */
+            /** @var \Shareforce\PhpWord\Reader\Word2007\AbstractPart $part Type hint */
             $part = new $partClass($docFile, $xmlFile);
             $part->setRels($relationships);
             $part->read($phpWord);

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
-use PhpOffice\PhpWord\Element\AbstractContainer;
-use PhpOffice\PhpWord\Element\TextRun;
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
+use Shareforce\PhpWord\Element\AbstractContainer;
+use Shareforce\PhpWord\Element\TextRun;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Abstract part reader
@@ -95,9 +95,9 @@ abstract class AbstractPart
     /**
      * Read w:p.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $parent
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $parent
      * @param string $docPart
      *
      * @todo Get font style for preserve text
@@ -202,9 +202,9 @@ abstract class AbstractPart
     /**
      * Read w:r.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $parent
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $parent
      * @param string $docPart
      * @param mixed $paragraphStyle
      *
@@ -333,7 +333,7 @@ abstract class AbstractPart
     /**
      * Read w:tbl.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @param mixed $parent
      * @param string $docPart
@@ -346,7 +346,7 @@ abstract class AbstractPart
             $tblStyle = $this->readTableStyle($xmlReader, $domNode);
         }
 
-        /** @var \PhpOffice\PhpWord\Element\Table $table Type hint */
+        /** @var \Shareforce\PhpWord\Element\Table $table Type hint */
         $table = $parent->addTable($tblStyle);
         $tblNodes = $xmlReader->getElements('*', $domNode);
         foreach ($tblNodes as $tblNode) {
@@ -391,7 +391,7 @@ abstract class AbstractPart
     /**
      * Read w:pPr.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @return array|null
      */
@@ -426,7 +426,7 @@ abstract class AbstractPart
     /**
      * Read w:rPr
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @return array|null
      */
@@ -472,7 +472,7 @@ abstract class AbstractPart
     /**
      * Read w:tblPr
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @return string|array|null
      * @todo Capture w:tblStylePr w:type="firstRow"
@@ -522,7 +522,7 @@ abstract class AbstractPart
     /**
      * Read w:tblpPr
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @return array
      */
@@ -547,7 +547,7 @@ abstract class AbstractPart
     /**
      * Read w:tblInd
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @return TblWidthComplexType
      */
@@ -565,7 +565,7 @@ abstract class AbstractPart
     /**
      * Read w:tcPr
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @return array
      */
@@ -633,7 +633,7 @@ abstract class AbstractPart
     /**
      * Read style definition
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $parentNode
      * @param array $styleDefs
      * @ignoreScrutinizerPatch

--- a/src/PhpWord/Reader/Word2007/DocPropsApp.php
+++ b/src/PhpWord/Reader/Word2007/DocPropsApp.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
 /**
  * Extended properties reader

--- a/src/PhpWord/Reader/Word2007/DocPropsCore.php
+++ b/src/PhpWord/Reader/Word2007/DocPropsCore.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Core properties reader
@@ -54,7 +54,7 @@ class DocPropsCore extends AbstractPart
     /**
      * Read core/extended document properties.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {

--- a/src/PhpWord/Reader/Word2007/DocPropsCustom.php
+++ b/src/PhpWord/Reader/Word2007/DocPropsCustom.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\Metadata\DocInfo;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\Metadata\DocInfo;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Custom properties reader
@@ -31,7 +31,7 @@ class DocPropsCustom extends AbstractPart
     /**
      * Read custom document properties.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {

--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\Element\Section;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Document reader
@@ -32,14 +32,14 @@ class Document extends AbstractPart
     /**
      * PhpWord object
      *
-     * @var \PhpOffice\PhpWord\PhpWord
+     * @var \Shareforce\PhpWord\PhpWord
      */
     private $phpWord;
 
     /**
      * Read document.xml.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {
@@ -64,7 +64,7 @@ class Document extends AbstractPart
      * Read header footer.
      *
      * @param array $settings
-     * @param \PhpOffice\PhpWord\Element\Section &$section
+     * @param \Shareforce\PhpWord\Element\Section &$section
      */
     private function readHeaderFooter($settings, Section &$section)
     {
@@ -97,7 +97,7 @@ class Document extends AbstractPart
     /**
      * Read w:sectPr
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $domNode
      * @ignoreScrutinizerPatch
      * @return array
@@ -141,9 +141,9 @@ class Document extends AbstractPart
     /**
      * Read w:p node.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $node
-     * @param \PhpOffice\PhpWord\Element\Section &$section
+     * @param \Shareforce\PhpWord\Element\Section &$section
      *
      * @todo <w:lastRenderedPageBreak>
      */
@@ -170,9 +170,9 @@ class Document extends AbstractPart
     /**
      * Read w:sectPr node.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $node
-     * @param \PhpOffice\PhpWord\Element\Section &$section
+     * @param \Shareforce\PhpWord\Element\Section &$section
      */
     private function readWSectPrNode(XMLReader $xmlReader, \DOMElement $node, Section &$section)
     {

--- a/src/PhpWord/Reader/Word2007/Endnotes.php
+++ b/src/PhpWord/Reader/Word2007/Endnotes.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
 /**
  * Endnotes reader

--- a/src/PhpWord/Reader/Word2007/Footnotes.php
+++ b/src/PhpWord/Reader/Word2007/Footnotes.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Footnotes reader
@@ -44,7 +44,7 @@ class Footnotes extends AbstractPart
     /**
      * Read (footnotes|endnotes).xml.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {
@@ -78,7 +78,7 @@ class Footnotes extends AbstractPart
      *
      * @param PhpWord $phpWord
      * @param int $relationId
-     * @return \PhpOffice\PhpWord\Element\AbstractContainer|null
+     * @return \Shareforce\PhpWord\Element\AbstractContainer|null
      */
     private function getElement(PhpWord $phpWord, $relationId)
     {

--- a/src/PhpWord/Reader/Word2007/Numbering.php
+++ b/src/PhpWord/Reader/Word2007/Numbering.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
 
 /**
  * Numbering reader
@@ -30,7 +30,7 @@ class Numbering extends AbstractPart
     /**
      * Read numbering.xml.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {
@@ -89,7 +89,7 @@ class Numbering extends AbstractPart
     /**
      * Read numbering level definition from w:abstractNum and w:num
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLReader $xmlReader
+     * @param \Shareforce\PhpWord\Shared\XMLReader $xmlReader
      * @param \DOMElement $subnode
      * @param int $levelId
      * @return array

--- a/src/PhpWord/Reader/Word2007/Settings.php
+++ b/src/PhpWord/Reader/Word2007/Settings.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\ComplexType\TrackChangesView;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
-use PhpOffice\PhpWord\Style\Language;
+use Shareforce\PhpWord\ComplexType\TrackChangesView;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\Style\Language;
 
 /**
  * Settings reader
@@ -45,7 +45,7 @@ class Settings extends AbstractPart
     /**
      * Read settings.xml.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {

--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLReader;
-use PhpOffice\PhpWord\Style\Language;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLReader;
+use Shareforce\PhpWord\Style\Language;
 
 /**
  * Styles reader
@@ -31,7 +31,7 @@ class Styles extends AbstractPart
     /**
      * Read styles.xml.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function read(PhpWord $phpWord)
     {

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 /**
  * PHPWord settings class
@@ -31,7 +31,7 @@ class Settings
      */
     const ZIPARCHIVE = 'ZipArchive';
     const PCLZIP = 'PclZip';
-    const OLD_LIB = 'PhpOffice\\PhpWord\\Shared\\ZipArchive'; // @deprecated 0.11
+    const OLD_LIB = 'Shareforce\\PhpWord\\Shared\\ZipArchive'; // @deprecated 0.11
 
     /**
      * PDF rendering libraries

--- a/src/PhpWord/Shared/AbstractEnum.php
+++ b/src/PhpWord/Shared/AbstractEnum.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 abstract class AbstractEnum
 {

--- a/src/PhpWord/Shared/Converter.php
+++ b/src/PhpWord/Shared/Converter.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * Common converter functions
@@ -281,35 +281,35 @@ class Converter
     public static function stringToRgb($value)
     {
         switch ($value) {
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_YELLOW:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_YELLOW:
                 return 'FFFF00';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_LIGHTGREEN:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_LIGHTGREEN:
                 return '90EE90';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_CYAN:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_CYAN:
                 return '00FFFF';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_MAGENTA:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_MAGENTA:
                 return 'FF00FF';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_BLUE:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_BLUE:
                 return '0000FF';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_RED:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_RED:
                 return 'FF0000';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKBLUE:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKBLUE:
                 return '00008B';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKCYAN:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKCYAN:
                 return '008B8B';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKGREEN:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKGREEN:
                 return '006400';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKMAGENTA:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKMAGENTA:
                 return '8B008B';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKRED:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKRED:
                 return '8B0000';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKYELLOW:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKYELLOW:
                 return '8B8B00';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKGRAY:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKGRAY:
                 return 'A9A9A9';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_LIGHTGRAY:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_LIGHTGRAY:
                 return 'D3D3D3';
-            case \PhpOffice\PhpWord\Style\Font::FGCOLOR_BLACK:
+            case \Shareforce\PhpWord\Style\Font::FGCOLOR_BLACK:
                 return '000000';
         }
 

--- a/src/PhpWord/Shared/Drawing.php
+++ b/src/PhpWord/Shared/Drawing.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * Drawing

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
-use PhpOffice\PhpWord\Element\AbstractContainer;
-use PhpOffice\PhpWord\Element\Row;
-use PhpOffice\PhpWord\Element\Table;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\SimpleType\NumberFormat;
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Element\AbstractContainer;
+use Shareforce\PhpWord\Element\Row;
+use Shareforce\PhpWord\Element\Table;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\NumberFormat;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
  * Common Html functions
@@ -43,7 +43,7 @@ class Html
      * Warning: Do not pass user-generated HTML here, as that would allow an attacker to read arbitrary
      * files or perform server-side request forgery by passing local file paths or URLs in <img>.
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element Where the parts need to be added
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element Where the parts need to be added
      * @param string $html The code to parse
      * @param bool $fullHTML If it's a full HTML, no need to add 'body' tag
      * @param bool $preserveWhiteSpace If false, the whitespaces between nodes will be removed
@@ -116,11 +116,11 @@ class Html
                         if (false !== strpos($val, '%')) {
                             // e.g. <table width="100%"> or <td width="50%">
                             $styles['width'] = (int) $val * 50;
-                            $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::PERCENT;
+                            $styles['unit'] = \Shareforce\PhpWord\SimpleType\TblWidth::PERCENT;
                         } else {
                             // e.g. <table width="250> where "250" = 250px (always pixels)
                             $styles['width'] = Converter::pixelToTwip($val);
-                            $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::TWIP;
+                            $styles['unit'] = \Shareforce\PhpWord\SimpleType\TblWidth::TWIP;
                         }
                         break;
                     case 'cellspacing':
@@ -149,7 +149,7 @@ class Html
      * Parse a node and add a corresponding element to the parent element.
      *
      * @param \DOMNode $node node to parse
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element object to add an element corresponding with the node
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element object to add an element corresponding with the node
      * @param array $styles Array with all styles
      * @param array $data Array to transport data to a next level in the DOM tree, for example level of listitems
      */
@@ -212,7 +212,7 @@ class Html
                 }
             }
             $method = "parse{$method}";
-            $newElement = call_user_func_array(array('PhpOffice\PhpWord\Shared\Html', $method), array_values($arguments));
+            $newElement = call_user_func_array(array('Shareforce\PhpWord\Shared\Html', $method), array_values($arguments));
 
             // Retrieve back variables from arguments
             foreach ($keys as $key) {
@@ -233,7 +233,7 @@ class Html
      * Parse child nodes.
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array $styles
      * @param array $data
      */
@@ -255,9 +255,9 @@ class Html
      * Parse paragraph node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
-     * @return \PhpOffice\PhpWord\Element\TextRun
+     * @return \Shareforce\PhpWord\Element\TextRun
      */
     protected static function parseParagraph($node, $element, &$styles)
     {
@@ -271,7 +271,7 @@ class Html
      * Parse input node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
      */
     protected static function parseInput($node, $element, &$styles)
@@ -294,10 +294,10 @@ class Html
     /**
      * Parse heading node
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
      * @param string $argument1 Name of heading style
-     * @return \PhpOffice\PhpWord\Element\TextRun
+     * @return \Shareforce\PhpWord\Element\TextRun
      *
      * @todo Think of a clever way of defining header styles, now it is only based on the assumption, that
      * Heading1 - Heading6 are already defined somewhere
@@ -314,7 +314,7 @@ class Html
      * Parse text node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
      */
     protected static function parseText($node, $element, &$styles)
@@ -358,7 +358,7 @@ class Html
      * Parse table node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
      * @return Table $element
      *
@@ -389,7 +389,7 @@ class Html
      * Parse a table row
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\Table $element
+     * @param \Shareforce\PhpWord\Element\Table $element
      * @param array &$styles
      * @return Row $element
      */
@@ -407,9 +407,9 @@ class Html
      * Parse table cell
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\Table $element
+     * @param \Shareforce\PhpWord\Element\Table $element
      * @param array &$styles
-     * @return \PhpOffice\PhpWord\Element\Cell|\PhpOffice\PhpWord\Element\TextRun $element
+     * @return \Shareforce\PhpWord\Element\Cell|\Shareforce\PhpWord\Element\TextRun $element
      */
     protected static function parseCell($node, $element, &$styles)
     {
@@ -506,7 +506,7 @@ class Html
      * Parse list node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
      * @param array &$data
      */
@@ -535,7 +535,7 @@ class Html
             }
 
             $levels = $style->getLevels();
-            /** @var \PhpOffice\PhpWord\Style\NumberingLevel */
+            /** @var \Shareforce\PhpWord\Style\NumberingLevel */
             $level = $levels[0];
             if ($start > 0) {
                 $level->setStart($start);
@@ -593,7 +593,7 @@ class Html
      * Parse list item node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
      * @param array $data
      *
@@ -662,20 +662,20 @@ class Html
                 case 'line-height':
                     $matches = array();
                     if ($cValue === 'normal') {
-                        $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
+                        $spacingLineRule = \Shareforce\PhpWord\SimpleType\LineSpacingRule::AUTO;
                         $spacing = 0;
                     } elseif (preg_match('/([0-9]+\.?[0-9]*[a-z]+)/', $cValue, $matches)) {
                         //matches number with a unit, e.g. 12px, 15pt, 20mm, ...
-                        $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::EXACT;
+                        $spacingLineRule = \Shareforce\PhpWord\SimpleType\LineSpacingRule::EXACT;
                         $spacing = Converter::cssToTwip($matches[1]);
                     } elseif (preg_match('/([0-9]+)%/', $cValue, $matches)) {
                         //matches percentages
-                        $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
+                        $spacingLineRule = \Shareforce\PhpWord\SimpleType\LineSpacingRule::AUTO;
                         //we are subtracting 1 line height because the Spacing writer is adding one line
                         $spacing = ((((int) $matches[1]) / 100) * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
                     } else {
                         //any other, wich is a multiplier. E.g. 1.2
-                        $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
+                        $spacingLineRule = \Shareforce\PhpWord\SimpleType\LineSpacingRule::AUTO;
                         //we are subtracting 1 line height because the Spacing writer is adding one line
                         $spacing = ($cValue * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
                     }
@@ -727,13 +727,13 @@ class Html
                 case 'width':
                     if (preg_match('/([0-9]+[a-z]+)/', $cValue, $matches)) {
                         $styles['width'] = Converter::cssToTwip($matches[1]);
-                        $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::TWIP;
+                        $styles['unit'] = \Shareforce\PhpWord\SimpleType\TblWidth::TWIP;
                     } elseif (preg_match('/([0-9]+)%/', $cValue, $matches)) {
                         $styles['width'] = $matches[1] * 50;
-                        $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::PERCENT;
+                        $styles['unit'] = \Shareforce\PhpWord\SimpleType\TblWidth::PERCENT;
                     } elseif (preg_match('/([0-9]+)/', $cValue, $matches)) {
                         $styles['width'] = $matches[1];
-                        $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::AUTO;
+                        $styles['unit'] = \Shareforce\PhpWord\SimpleType\TblWidth::AUTO;
                     }
                     break;
                 case 'border':
@@ -781,9 +781,9 @@ class Html
      * Parse image node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      *
-     * @return \PhpOffice\PhpWord\Element\Image
+     * @return \Shareforce\PhpWord\Element\Image
      **/
     protected static function parseImage($node, $element)
     {
@@ -797,12 +797,12 @@ class Html
                 case 'width':
                     $width = $attribute->value;
                     $style['width'] = $width;
-                    $style['unit'] = \PhpOffice\PhpWord\Style\Image::UNIT_PX;
+                    $style['unit'] = \Shareforce\PhpWord\Style\Image::UNIT_PX;
                     break;
                 case 'height':
                     $height = $attribute->value;
                     $style['height'] = $height;
-                    $style['unit'] = \PhpOffice\PhpWord\Style\Image::UNIT_PX;
+                    $style['unit'] = \Shareforce\PhpWord\Style\Image::UNIT_PX;
                     break;
                 case 'style':
                     $styleattr = explode(';', $attribute->value);
@@ -812,17 +812,17 @@ class Html
                             switch ($k) {
                                 case 'float':
                                     if (trim($v) == 'right') {
-                                        $style['hPos'] = \PhpOffice\PhpWord\Style\Image::POS_RIGHT;
-                                        $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_MARGIN; // inner section area
-                                        $style['pos'] = \PhpOffice\PhpWord\Style\Image::POS_RELATIVE;
-                                        $style['wrap'] = \PhpOffice\PhpWord\Style\Image::WRAP_TIGHT;
+                                        $style['hPos'] = \Shareforce\PhpWord\Style\Image::POS_RIGHT;
+                                        $style['hPosRelTo'] = \Shareforce\PhpWord\Style\Image::POS_RELTO_MARGIN; // inner section area
+                                        $style['pos'] = \Shareforce\PhpWord\Style\Image::POS_RELATIVE;
+                                        $style['wrap'] = \Shareforce\PhpWord\Style\Image::WRAP_TIGHT;
                                         $style['overlap'] = true;
                                     }
                                     if (trim($v) == 'left') {
-                                        $style['hPos'] = \PhpOffice\PhpWord\Style\Image::POS_LEFT;
-                                        $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_MARGIN; // inner section area
-                                        $style['pos'] = \PhpOffice\PhpWord\Style\Image::POS_RELATIVE;
-                                        $style['wrap'] = \PhpOffice\PhpWord\Style\Image::WRAP_TIGHT;
+                                        $style['hPos'] = \Shareforce\PhpWord\Style\Image::POS_LEFT;
+                                        $style['hPosRelTo'] = \Shareforce\PhpWord\Style\Image::POS_RELTO_MARGIN; // inner section area
+                                        $style['pos'] = \Shareforce\PhpWord\Style\Image::POS_RELATIVE;
+                                        $style['wrap'] = \Shareforce\PhpWord\Style\Image::WRAP_TIGHT;
                                         $style['overlap'] = true;
                                     }
                                     break;
@@ -916,7 +916,7 @@ class Html
     }
 
     /**
-     * Transforms a HTML/CSS alignment into a \PhpOffice\PhpWord\SimpleType\Jc
+     * Transforms a HTML/CSS alignment into a \Shareforce\PhpWord\SimpleType\Jc
      *
      * @param string $cssAlignment
      * @return string|null
@@ -990,7 +990,7 @@ class Html
     /**
      * Parse line break
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      */
     protected static function parseLineBreak($element)
     {
@@ -1001,7 +1001,7 @@ class Html
      * Parse link node
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      * @param array $styles
      */
     protected static function parseLink($node, $element, &$styles)
@@ -1028,7 +1028,7 @@ class Html
      * Note: Word rule is not the same as HTML's <hr> since it does not support width and thus neither alignment
      *
      * @param \DOMNode $node
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $element
      */
     protected static function parseHorizRule($node, $element)
     {

--- a/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
+++ b/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared\Microsoft;
+namespace Shareforce\PhpWord\Shared\Microsoft;
 
 /**
  * Password encoder for microsoft office applications

--- a/src/PhpWord/Shared/OLERead.php
+++ b/src/PhpWord/Shared/OLERead.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
-use PhpOffice\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Exception\Exception;
 
 defined('IDENTIFIER_OLE') ||
 define('IDENTIFIER_OLE', pack('CCCCCCCC', 0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1));

--- a/src/PhpWord/Shared/Text.php
+++ b/src/PhpWord/Shared/Text.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * Text

--- a/src/PhpWord/Shared/XMLReader.php
+++ b/src/PhpWord/Shared/XMLReader.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * XML Reader wrapper

--- a/src/PhpWord/Shared/XMLWriter.php
+++ b/src/PhpWord/Shared/XMLWriter.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * XMLWriter
@@ -47,7 +47,7 @@ class XMLWriter extends \XMLWriter
     private $tempFileName = '';
 
     /**
-     * Create a new \PhpOffice\PhpWord\Shared\XMLWriter instance
+     * Create a new \Shareforce\PhpWord\Shared\XMLWriter instance
      *
      * @param int $pTemporaryStorage Temporary storage location
      * @param string $pTemporaryStorageDir Temporary storage folder

--- a/src/PhpWord/Shared/ZipArchive.php
+++ b/src/PhpWord/Shared/ZipArchive.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Settings;
 
 /**
  * ZipArchive wrapper
@@ -158,7 +158,7 @@ class ZipArchive
     /**
      * Close the active archive
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return bool
      *

--- a/src/PhpWord/SimpleType/Border.php
+++ b/src/PhpWord/SimpleType/Border.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Border Styles.

--- a/src/PhpWord/SimpleType/DocProtect.php
+++ b/src/PhpWord/SimpleType/DocProtect.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Document Protection Types

--- a/src/PhpWord/SimpleType/Jc.php
+++ b/src/PhpWord/SimpleType/Jc.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Horizontal Alignment Type.
@@ -27,7 +27,7 @@ use PhpOffice\PhpWord\Shared\AbstractEnum;
  *
  * @since 0.13.0
  *
- * @see \PhpOffice\PhpWord\SimpleType\JcTable For table alignment modes available since ISO/IEC-29500:2008.
+ * @see \Shareforce\PhpWord\SimpleType\JcTable For table alignment modes available since ISO/IEC-29500:2008.
  * @see  http://www.datypic.com/sc/ooxml/t-w_ST_Jc.html
  */
 final class Jc extends AbstractEnum

--- a/src/PhpWord/SimpleType/JcTable.php
+++ b/src/PhpWord/SimpleType/JcTable.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Table Alignment Type.

--- a/src/PhpWord/SimpleType/LineSpacingRule.php
+++ b/src/PhpWord/SimpleType/LineSpacingRule.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Line Spacing Rule

--- a/src/PhpWord/SimpleType/NumberFormat.php
+++ b/src/PhpWord/SimpleType/NumberFormat.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Numbering Format.

--- a/src/PhpWord/SimpleType/TblWidth.php
+++ b/src/PhpWord/SimpleType/TblWidth.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Table Width Units

--- a/src/PhpWord/SimpleType/TextAlignment.php
+++ b/src/PhpWord/SimpleType/TextAlignment.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Magnification Preset Values

--- a/src/PhpWord/SimpleType/VerticalJc.php
+++ b/src/PhpWord/SimpleType/VerticalJc.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Vertical Alignment Type.

--- a/src/PhpWord/SimpleType/Zoom.php
+++ b/src/PhpWord/SimpleType/Zoom.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\SimpleType;
+namespace Shareforce\PhpWord\SimpleType;
 
-use PhpOffice\PhpWord\Shared\AbstractEnum;
+use Shareforce\PhpWord\Shared\AbstractEnum;
 
 /**
  * Magnification Preset Values

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Style\AbstractStyle;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Numbering;
-use PhpOffice\PhpWord\Style\Paragraph;
-use PhpOffice\PhpWord\Style\Table;
+use Shareforce\PhpWord\Style\AbstractStyle;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Numbering;
+use Shareforce\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Style\Table;
 
 /**
  * Style collection
@@ -39,8 +39,8 @@ class Style
      * Add paragraph style
      *
      * @param string $styleName
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles
-     * @return \PhpOffice\PhpWord\Style\Paragraph
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $styles
+     * @return \Shareforce\PhpWord\Style\Paragraph
      */
     public static function addParagraphStyle($styleName, $styles)
     {
@@ -51,9 +51,9 @@ class Style
      * Add font style
      *
      * @param string $styleName
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $fontStyle
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraphStyle
-     * @return \PhpOffice\PhpWord\Style\Font
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $fontStyle
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $paragraphStyle
+     * @return \Shareforce\PhpWord\Style\Font
      */
     public static function addFontStyle($styleName, $fontStyle, $paragraphStyle = null)
     {
@@ -64,8 +64,8 @@ class Style
      * Add link style
      *
      * @param string $styleName
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles
-     * @return \PhpOffice\PhpWord\Style\Font
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $styles
+     * @return \Shareforce\PhpWord\Style\Font
      */
     public static function addLinkStyle($styleName, $styles)
     {
@@ -76,8 +76,8 @@ class Style
      * Add numbering style
      *
      * @param string $styleName
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styleValues
-     * @return \PhpOffice\PhpWord\Style\Numbering
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $styleValues
+     * @return \Shareforce\PhpWord\Style\Numbering
      * @since 0.10.0
      */
     public static function addNumberingStyle($styleName, $styleValues)
@@ -89,9 +89,9 @@ class Style
      * Add title style
      *
      * @param int|null $depth Provide null to set title font
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $fontStyle
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraphStyle
-     * @return \PhpOffice\PhpWord\Style\Font
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $fontStyle
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $paragraphStyle
+     * @return \Shareforce\PhpWord\Style\Font
      */
     public static function addTitleStyle($depth, $fontStyle, $paragraphStyle = null)
     {
@@ -110,7 +110,7 @@ class Style
      * @param string $styleName
      * @param array $styleTable
      * @param array|null $styleFirstRow
-     * @return \PhpOffice\PhpWord\Style\Table
+     * @return \Shareforce\PhpWord\Style\Table
      */
     public static function addTableStyle($styleName, $styleTable, $styleFirstRow = null)
     {
@@ -141,8 +141,8 @@ class Style
     /**
      * Set default paragraph style
      *
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles Paragraph style definition
-     * @return \PhpOffice\PhpWord\Style\Paragraph
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $styles Paragraph style definition
+     * @return \Shareforce\PhpWord\Style\Paragraph
      */
     public static function setDefaultParagraphStyle($styles)
     {
@@ -152,7 +152,7 @@ class Style
     /**
      * Get all styles
      *
-     * @return \PhpOffice\PhpWord\Style\AbstractStyle[]
+     * @return \Shareforce\PhpWord\Style\AbstractStyle[]
      */
     public static function getStyles()
     {
@@ -163,7 +163,7 @@ class Style
      * Get style by name
      *
      * @param string $styleName
-     * @return \PhpOffice\PhpWord\Style\AbstractStyle Paragraph|Font|Table|Numbering
+     * @return \Shareforce\PhpWord\Style\AbstractStyle Paragraph|Font|Table|Numbering
      */
     public static function getStyle($styleName)
     {
@@ -180,9 +180,9 @@ class Style
      * The $styleValues could be an array or object
      *
      * @param string $name
-     * @param \PhpOffice\PhpWord\Style\AbstractStyle $style
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $value
-     * @return \PhpOffice\PhpWord\Style\AbstractStyle
+     * @param \Shareforce\PhpWord\Style\AbstractStyle $style
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $value
+     * @return \Shareforce\PhpWord\Style\AbstractStyle
      */
     private static function setStyleValues($name, $style, $value = null)
     {

--- a/src/PhpWord/Style/AbstractStyle.php
+++ b/src/PhpWord/Style/AbstractStyle.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\Shared\Text;
+use Shareforce\PhpWord\Shared\Text;
 
 /**
  * Abstract style class
@@ -129,7 +129,7 @@ abstract class AbstractStyle
     /**
      * Return style value of child style object, e.g. `left` from `Indentation` child style of `Paragraph`
      *
-     * @param \PhpOffice\PhpWord\Style\AbstractStyle $substyleObject
+     * @param \Shareforce\PhpWord\Style\AbstractStyle $substyleObject
      * @param string $substyleProperty
      * @return mixed
      * @since 0.12.0
@@ -306,7 +306,7 @@ abstract class AbstractStyle
     {
         $styleClass = substr(get_class($this), 0, strrpos(get_class($this), '\\')) . '\\' . $styleName;
         if (is_array($value)) {
-            /** @var \PhpOffice\PhpWord\Style\AbstractStyle $style Type hint */
+            /** @var \Shareforce\PhpWord\Style\AbstractStyle $style Type hint */
             if (!$style instanceof $styleClass) {
                 $style = new $styleClass();
             }

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Border style

--- a/src/PhpWord/Style/Cell.php
+++ b/src/PhpWord/Style/Cell.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\TblWidth;
-use PhpOffice\PhpWord\SimpleType\VerticalJc;
+use Shareforce\PhpWord\SimpleType\TblWidth;
+use Shareforce\PhpWord\SimpleType\VerticalJc;
 
 /**
  * Table cell style
@@ -29,19 +29,19 @@ class Cell extends Border
      * Vertical alignment constants
      *
      * @const string
-     * @deprecated Use \PhpOffice\PhpWord\SimpleType\VerticalJc::TOP instead
+     * @deprecated Use \Shareforce\PhpWord\SimpleType\VerticalJc::TOP instead
      */
     const VALIGN_TOP = 'top';
     /**
-     * @deprecated Use \PhpOffice\PhpWord\SimpleType\VerticalJc::CENTER instead
+     * @deprecated Use \Shareforce\PhpWord\SimpleType\VerticalJc::CENTER instead
      */
     const VALIGN_CENTER = 'center';
     /**
-     * @deprecated Use \PhpOffice\PhpWord\SimpleType\VerticalJc::BOTTOM instead
+     * @deprecated Use \Shareforce\PhpWord\SimpleType\VerticalJc::BOTTOM instead
      */
     const VALIGN_BOTTOM = 'bottom';
     /**
-     * @deprecated Use \PhpOffice\PhpWord\SimpleType\VerticalJc::BOTH instead
+     * @deprecated Use \Shareforce\PhpWord\SimpleType\VerticalJc::BOTH instead
      */
     const VALIGN_BOTH = 'both';
 
@@ -120,7 +120,7 @@ class Cell extends Border
     /**
      * Shading
      *
-     * @var \PhpOffice\PhpWord\Style\Shading
+     * @var \Shareforce\PhpWord\Style\Shading
      */
     private $shading;
 
@@ -261,7 +261,7 @@ class Cell extends Border
     /**
      * Get shading
      *
-     * @return \PhpOffice\PhpWord\Style\Shading
+     * @return \Shareforce\PhpWord\Style\Shading
      */
     public function getShading()
     {

--- a/src/PhpWord/Style/Chart.php
+++ b/src/PhpWord/Style/Chart.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Chart style

--- a/src/PhpWord/Style/Extrusion.php
+++ b/src/PhpWord/Style/Extrusion.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * 3D extrusion style

--- a/src/PhpWord/Style/Fill.php
+++ b/src/PhpWord/Style/Fill.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Fill style

--- a/src/PhpWord/Style/Font.php
+++ b/src/PhpWord/Style/Font.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Font style
@@ -219,14 +219,14 @@ class Font extends AbstractStyle
     /**
      * Paragraph style
      *
-     * @var \PhpOffice\PhpWord\Style\Paragraph
+     * @var \Shareforce\PhpWord\Style\Paragraph
      */
     private $paragraph;
 
     /**
      * Shading
      *
-     * @var \PhpOffice\PhpWord\Style\Shading
+     * @var \Shareforce\PhpWord\Style\Shading
      */
     private $shading;
 
@@ -248,7 +248,7 @@ class Font extends AbstractStyle
     /**
      * Languages
      *
-     * @var \PhpOffice\PhpWord\Style\Language
+     * @var \Shareforce\PhpWord\Style\Language
      */
     private $lang;
 
@@ -272,7 +272,7 @@ class Font extends AbstractStyle
      * Create new font style
      *
      * @param string $type Type of font
-     * @param array|string|\PhpOffice\PhpWord\Style\AbstractStyle $paragraph Paragraph styles definition
+     * @param array|string|\Shareforce\PhpWord\Style\AbstractStyle $paragraph Paragraph styles definition
      */
     public function __construct($type = 'text', $paragraph = null)
     {
@@ -658,7 +658,7 @@ class Font extends AbstractStyle
      * Set background
      *
      * @param string $value
-     * @return \PhpOffice\PhpWord\Style\Table
+     * @return \Shareforce\PhpWord\Style\Table
      */
     public function setBgColor($value = null)
     {
@@ -783,7 +783,7 @@ class Font extends AbstractStyle
     /**
      * Get paragraph style
      *
-     * @return \PhpOffice\PhpWord\Style\Paragraph
+     * @return \Shareforce\PhpWord\Style\Paragraph
      */
     public function getParagraph()
     {
@@ -829,7 +829,7 @@ class Font extends AbstractStyle
     /**
      * Get shading
      *
-     * @return \PhpOffice\PhpWord\Style\Shading
+     * @return \Shareforce\PhpWord\Style\Shading
      */
     public function getShading()
     {
@@ -852,7 +852,7 @@ class Font extends AbstractStyle
     /**
      * Get language
      *
-     * @return \PhpOffice\PhpWord\Style\Language
+     * @return \Shareforce\PhpWord\Style\Language
      */
     public function getLang()
     {

--- a/src/PhpWord/Style/Frame.php
+++ b/src/PhpWord/Style/Frame.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
  * Frame defines the size and position of an object

--- a/src/PhpWord/Style/Image.php
+++ b/src/PhpWord/Style/Image.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Image and memory image style

--- a/src/PhpWord/Style/Indentation.php
+++ b/src/PhpWord/Style/Indentation.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Paragraph indentation style

--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Language

--- a/src/PhpWord/Style/Line.php
+++ b/src/PhpWord/Style/Line.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Line style

--- a/src/PhpWord/Style/LineNumbering.php
+++ b/src/PhpWord/Style/LineNumbering.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Line numbering style

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\Style;
+use Shareforce\PhpWord\Style;
 
 /**
  * List item style

--- a/src/PhpWord/Style/Numbering.php
+++ b/src/PhpWord/Style/Numbering.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Numbering style

--- a/src/PhpWord/Style/NumberingLevel.php
+++ b/src/PhpWord/Style/NumberingLevel.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\SimpleType\NumberFormat;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\NumberFormat;
 
 /**
  * Numbering level definition
@@ -44,7 +44,7 @@ class NumberingLevel extends AbstractStyle
     private $start = 1;
 
     /**
-     * Numbering format w:numFmt, one of PhpOffice\PhpWord\SimpleType\NumberFormat
+     * Numbering format w:numFmt, one of Shareforce\PhpWord\SimpleType\NumberFormat
      *
      * @var string
      * @see  http://www.schemacentral.com/sc/ooxml/t-w_ST_NumberFormat.html
@@ -86,7 +86,7 @@ class NumberingLevel extends AbstractStyle
     /**
      * Justification, w:lvlJc
      *
-     * @var string, one of PhpOffice\PhpWord\SimpleType\Jc
+     * @var string, one of Shareforce\PhpWord\SimpleType\Jc
      */
     private $alignment = '';
 

--- a/src/PhpWord/Style/Outline.php
+++ b/src/PhpWord/Style/Outline.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Outline defines the line/border of the object

--- a/src/PhpWord/Style/Paper.php
+++ b/src/PhpWord/Style/Paper.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Shared\Converter;
 
 /**
  * Paper size from ISO/IEC 29500-1:2012 pg. 1656-1657

--- a/src/PhpWord/Style/Paragraph.php
+++ b/src/PhpWord/Style/Paragraph.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\Exception\InvalidStyleException;
-use PhpOffice\PhpWord\Shared\Text;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\SimpleType\TextAlignment;
+use Shareforce\PhpWord\Exception\InvalidStyleException;
+use Shareforce\PhpWord\Shared\Text;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\TextAlignment;
 
 /**
  * Paragraph style
@@ -85,14 +85,14 @@ class Paragraph extends Border
     /**
      * Indentation
      *
-     * @var \PhpOffice\PhpWord\Style\Indentation|null
+     * @var \Shareforce\PhpWord\Style\Indentation|null
      */
     private $indentation;
 
     /**
      * Spacing
      *
-     * @var \PhpOffice\PhpWord\Style\Spacing
+     * @var \Shareforce\PhpWord\Style\Spacing
      */
     private $spacing;
 
@@ -148,14 +148,14 @@ class Paragraph extends Border
     /**
      * Set of Custom Tab Stops
      *
-     * @var \PhpOffice\PhpWord\Style\Tab[]
+     * @var \Shareforce\PhpWord\Style\Tab[]
      */
     private $tabs = array();
 
     /**
      * Shading
      *
-     * @var \PhpOffice\PhpWord\Style\Shading
+     * @var \Shareforce\PhpWord\Style\Shading
      */
     private $shading;
 
@@ -345,7 +345,7 @@ class Paragraph extends Border
     /**
      * Get shading
      *
-     * @return \PhpOffice\PhpWord\Style\Indentation
+     * @return \Shareforce\PhpWord\Style\Indentation
      */
     public function getIndentation()
     {
@@ -410,7 +410,7 @@ class Paragraph extends Border
     /**
      * Get spacing
      *
-     * @return \PhpOffice\PhpWord\Style\Spacing
+     * @return \Shareforce\PhpWord\Style\Spacing
      * @todo Rename to getSpacing in 1.0
      */
     public function getSpace()
@@ -509,7 +509,7 @@ class Paragraph extends Border
      * Set the spacing line rule
      *
      * @param string $value Possible values are defined in LineSpacingRule
-     * @return \PhpOffice\PhpWord\Style\Paragraph
+     * @return \Shareforce\PhpWord\Style\Paragraph
      */
     public function setSpacingLineRule($value)
     {
@@ -531,7 +531,7 @@ class Paragraph extends Border
      *
      * @param int|float|string $lineHeight
      *
-     * @throws \PhpOffice\PhpWord\Exception\InvalidStyleException
+     * @throws \Shareforce\PhpWord\Exception\InvalidStyleException
      * @return self
      */
     public function setLineHeight($lineHeight)
@@ -546,7 +546,7 @@ class Paragraph extends Border
 
         $this->lineHeight = $lineHeight;
         $this->setSpacing(($lineHeight - 1) * self::LINE_HEIGHT);
-        $this->setSpacingLineRule(\PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO);
+        $this->setSpacingLineRule(\Shareforce\PhpWord\SimpleType\LineSpacingRule::AUTO);
 
         return $this;
     }
@@ -692,7 +692,7 @@ class Paragraph extends Border
     /**
      * Get tabs
      *
-     * @return \PhpOffice\PhpWord\Style\Tab[]
+     * @return \Shareforce\PhpWord\Style\Tab[]
      */
     public function getTabs()
     {
@@ -765,7 +765,7 @@ class Paragraph extends Border
     /**
      * Get shading
      *
-     * @return \PhpOffice\PhpWord\Style\Shading
+     * @return \Shareforce\PhpWord\Style\Shading
      */
     public function getShading()
     {

--- a/src/PhpWord/Style/Row.php
+++ b/src/PhpWord/Style/Row.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Table row style

--- a/src/PhpWord/Style/Section.php
+++ b/src/PhpWord/Style/Section.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\SimpleType\VerticalJc;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\SimpleType\VerticalJc;
 
 /**
  * Section settings
@@ -58,7 +58,7 @@ class Section extends Border
     /**
      * Paper size
      *
-     * @var \PhpOffice\PhpWord\Style\Paper
+     * @var \Shareforce\PhpWord\Style\Paper
      */
     private $paper;
 
@@ -164,14 +164,14 @@ class Section extends Border
     /**
      * Line numbering
      *
-     * @var \PhpOffice\PhpWord\Style\LineNumbering
+     * @var \Shareforce\PhpWord\Style\LineNumbering
      * @see  http://www.schemacentral.com/sc/ooxml/e-w_lnNumType-1.html
      */
     private $lineNumbering;
 
     /**
      * Vertical Text Alignment on Page
-     * One of \PhpOffice\PhpWord\SimpleType\VerticalJc
+     * One of \Shareforce\PhpWord\SimpleType\VerticalJc
      *
      * @var string
      */
@@ -301,7 +301,7 @@ class Section extends Border
     /**
      * @param int|float|null $value
      *
-     * @return \PhpOffice\PhpWord\Style\Section
+     * @return \Shareforce\PhpWord\Style\Section
      *
      * @since 0.12.0
      */
@@ -327,7 +327,7 @@ class Section extends Border
     /**
      * @param int|float|null $value
      *
-     * @return \PhpOffice\PhpWord\Style\Section
+     * @return \Shareforce\PhpWord\Style\Section
      *
      * @since 0.12.0
      */
@@ -594,7 +594,7 @@ class Section extends Border
     /**
      * Get line numbering
      *
-     * @return \PhpOffice\PhpWord\Style\LineNumbering
+     * @return \Shareforce\PhpWord\Style\LineNumbering
      */
     public function getLineNumbering()
     {

--- a/src/PhpWord/Style/Shading.php
+++ b/src/PhpWord/Style/Shading.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Shading style

--- a/src/PhpWord/Style/Shadow.php
+++ b/src/PhpWord/Style/Shadow.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Shadow style

--- a/src/PhpWord/Style/Shape.php
+++ b/src/PhpWord/Style/Shape.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Shape style
@@ -50,35 +50,35 @@ class Shape extends AbstractStyle
     /**
      * Frame
      *
-     * @var \PhpOffice\PhpWord\Style\Frame
+     * @var \Shareforce\PhpWord\Style\Frame
      */
     private $frame;
 
     /**
      * Fill
      *
-     * @var \PhpOffice\PhpWord\Style\Fill
+     * @var \Shareforce\PhpWord\Style\Fill
      */
     private $fill;
 
     /**
      * Outline
      *
-     * @var \PhpOffice\PhpWord\Style\Outline
+     * @var \Shareforce\PhpWord\Style\Outline
      */
     private $outline;
 
     /**
      * Shadow
      *
-     * @var \PhpOffice\PhpWord\Style\Shadow
+     * @var \Shareforce\PhpWord\Style\Shadow
      */
     private $shadow;
 
     /**
      * 3D extrusion
      *
-     * @var \PhpOffice\PhpWord\Style\Extrusion
+     * @var \Shareforce\PhpWord\Style\Extrusion
      */
     private $extrusion;
 
@@ -141,7 +141,7 @@ class Shape extends AbstractStyle
     /**
      * Get frame
      *
-     * @return \PhpOffice\PhpWord\Style\Frame
+     * @return \Shareforce\PhpWord\Style\Frame
      */
     public function getFrame()
     {
@@ -164,7 +164,7 @@ class Shape extends AbstractStyle
     /**
      * Get fill
      *
-     * @return \PhpOffice\PhpWord\Style\Fill
+     * @return \Shareforce\PhpWord\Style\Fill
      */
     public function getFill()
     {
@@ -187,7 +187,7 @@ class Shape extends AbstractStyle
     /**
      * Get outline
      *
-     * @return \PhpOffice\PhpWord\Style\Outline
+     * @return \Shareforce\PhpWord\Style\Outline
      */
     public function getOutline()
     {
@@ -210,7 +210,7 @@ class Shape extends AbstractStyle
     /**
      * Get shadow
      *
-     * @return \PhpOffice\PhpWord\Style\Shadow
+     * @return \Shareforce\PhpWord\Style\Shadow
      */
     public function getShadow()
     {
@@ -233,7 +233,7 @@ class Shape extends AbstractStyle
     /**
      * Get 3D extrusion
      *
-     * @return \PhpOffice\PhpWord\Style\Extrusion
+     * @return \Shareforce\PhpWord\Style\Extrusion
      */
     public function getExtrusion()
     {

--- a/src/PhpWord/Style/Spacing.php
+++ b/src/PhpWord/Style/Spacing.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\LineSpacingRule;
+use Shareforce\PhpWord\SimpleType\LineSpacingRule;
 
 /**
  * Spacing between lines and above/below paragraph style

--- a/src/PhpWord/Style/TOC.php
+++ b/src/PhpWord/Style/TOC.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * TOC style

--- a/src/PhpWord/Style/Tab.php
+++ b/src/PhpWord/Style/Tab.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * Tab style

--- a/src/PhpWord/Style/Table.php
+++ b/src/PhpWord/Style/Table.php
@@ -15,25 +15,25 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\SimpleType\JcTable;
-use PhpOffice\PhpWord\SimpleType\TblWidth;
+use Shareforce\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\JcTable;
+use Shareforce\PhpWord\SimpleType\TblWidth;
 
 class Table extends Border
 {
     /**
-     * @deprecated Use \PhpOffice\PhpWord\SimpleType\TblWidth::AUTO instead
+     * @deprecated Use \Shareforce\PhpWord\SimpleType\TblWidth::AUTO instead
      */
     const WIDTH_AUTO = 'auto'; // Automatically determined width
     /**
-     * @deprecated Use \PhpOffice\PhpWord\SimpleType\TblWidth::PERCENT instead
+     * @deprecated Use \Shareforce\PhpWord\SimpleType\TblWidth::PERCENT instead
      */
     const WIDTH_PERCENT = 'pct'; // Width in fiftieths (1/50) of a percent (1% = 50 unit)
     /**
-     * @deprecated Use \PhpOffice\PhpWord\SimpleType\TblWidth::TWIP instead
+     * @deprecated Use \Shareforce\PhpWord\SimpleType\TblWidth::TWIP instead
      */
     const WIDTH_TWIP = 'dxa'; // Width in twentieths (1/20) of a point (twip)
 
@@ -61,7 +61,7 @@ class Table extends Border
     /**
      * Style for first row
      *
-     * @var \PhpOffice\PhpWord\Style\Table
+     * @var \Shareforce\PhpWord\Style\Table
      */
     private $firstRowStyle;
 
@@ -124,7 +124,7 @@ class Table extends Border
     /**
      * Shading
      *
-     * @var \PhpOffice\PhpWord\Style\Shading
+     * @var \Shareforce\PhpWord\Style\Shading
      */
     private $shading;
 
@@ -156,7 +156,7 @@ class Table extends Border
     /**
      * Position
      *
-     * @var \PhpOffice\PhpWord\Style\TablePosition
+     * @var \Shareforce\PhpWord\Style\TablePosition
      */
     private $position;
 
@@ -218,7 +218,7 @@ class Table extends Border
     /**
      * Set first row
      *
-     * @return \PhpOffice\PhpWord\Style\Table
+     * @return \Shareforce\PhpWord\Style\Table
      */
     public function getFirstRow()
     {
@@ -536,7 +536,7 @@ class Table extends Border
     /**
      * Get shading
      *
-     * @return \PhpOffice\PhpWord\Style\Shading
+     * @return \Shareforce\PhpWord\Style\Shading
      */
     public function getShading()
     {
@@ -724,7 +724,7 @@ class Table extends Border
     /**
      * Get position
      *
-     * @return \PhpOffice\PhpWord\Style\TablePosition
+     * @return \Shareforce\PhpWord\Style\TablePosition
      */
     public function getPosition()
     {

--- a/src/PhpWord/Style/TablePosition.php
+++ b/src/PhpWord/Style/TablePosition.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * TablePosition style

--- a/src/PhpWord/Style/TextBox.php
+++ b/src/PhpWord/Style/TextBox.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
  * TextBox style

--- a/src/PhpWord/Template.php
+++ b/src/PhpWord/Template.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 /**
- * @deprecated 0.12.0 Use `\PhpOffice\PhpWord\TemplateProcessor` instead.
+ * @deprecated 0.12.0 Use `\Shareforce\PhpWord\TemplateProcessor` instead.
  *
  * @codeCoverageIgnore
  */

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -16,16 +16,16 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Escaper\RegExp;
-use PhpOffice\PhpWord\Escaper\Xml;
-use PhpOffice\PhpWord\Exception\CopyFileException;
-use PhpOffice\PhpWord\Exception\CreateTemporaryFileException;
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\Shared\Text;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Shared\ZipArchive;
+use Shareforce\PhpWord\Escaper\RegExp;
+use Shareforce\PhpWord\Escaper\Xml;
+use Shareforce\PhpWord\Exception\CopyFileException;
+use Shareforce\PhpWord\Exception\CreateTemporaryFileException;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Shared\Text;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Shared\ZipArchive;
 
 class TemplateProcessor
 {
@@ -97,8 +97,8 @@ class TemplateProcessor
      *
      * @param string $documentTemplate The fully qualified template filename
      *
-     * @throws \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
-     * @throws \PhpOffice\PhpWord\Exception\CopyFileException
+     * @throws \Shareforce\PhpWord\Exception\CreateTemporaryFileException
+     * @throws \Shareforce\PhpWord\Exception\CopyFileException
      */
     public function __construct($documentTemplate)
     {
@@ -138,7 +138,7 @@ class TemplateProcessor
      * To replace an image: $templateProcessor->zip()->AddFromString("word/media/image1.jpg", file_get_contents($file));<br>
      * To read a file: $templateProcessor->zip()->getFromName("word/media/image1.jpg");
      *
-     * @return \PhpOffice\PhpWord\Shared\ZipArchive
+     * @return \Shareforce\PhpWord\Shared\ZipArchive
      */
     public function zip()
     {
@@ -165,7 +165,7 @@ class TemplateProcessor
      * @param string $xml
      * @param \XSLTProcessor $xsltProcessor
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return string
      */
@@ -220,7 +220,7 @@ class TemplateProcessor
      * @param array $xslOptions
      * @param string $xslOptionsUri
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      */
     public function applyXslStyleSheet($xslDomDocument, $xslOptions = array(), $xslOptionsUri = '')
     {
@@ -266,15 +266,15 @@ class TemplateProcessor
 
     /**
      * @param string $search
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $complexType
+     * @param \Shareforce\PhpWord\Element\AbstractElement $complexType
      */
-    public function setComplexValue($search, \PhpOffice\PhpWord\Element\AbstractElement $complexType)
+    public function setComplexValue($search, \Shareforce\PhpWord\Element\AbstractElement $complexType)
     {
         $elementName = substr(get_class($complexType), strrpos(get_class($complexType), '\\') + 1);
-        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
+        $objectClass = 'Shareforce\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
 
         $xmlWriter = new XMLWriter();
-        /** @var \PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement $elementWriter */
+        /** @var \Shareforce\PhpWord\Writer\Word2007\Element\AbstractElement $elementWriter */
         $elementWriter = new $objectClass($xmlWriter, $complexType, true);
         $elementWriter->write();
 
@@ -294,15 +294,15 @@ class TemplateProcessor
 
     /**
      * @param string $search
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $complexType
+     * @param \Shareforce\PhpWord\Element\AbstractElement $complexType
      */
-    public function setComplexBlock($search, \PhpOffice\PhpWord\Element\AbstractElement $complexType)
+    public function setComplexBlock($search, \Shareforce\PhpWord\Element\AbstractElement $complexType)
     {
         $elementName = substr(get_class($complexType), strrpos(get_class($complexType), '\\') + 1);
-        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
+        $objectClass = 'Shareforce\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
 
         $xmlWriter = new XMLWriter();
-        /** @var \PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement $elementWriter */
+        /** @var \Shareforce\PhpWord\Writer\Word2007\Element\AbstractElement $elementWriter */
         $elementWriter = new $objectClass($xmlWriter, $complexType, false);
         $elementWriter->write();
 
@@ -358,12 +358,12 @@ class TemplateProcessor
 
     /**
      * @param string $search
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $complexType
+     * @param \Shareforce\PhpWord\Element\AbstractElement $complexType
      */
-    public function setChart($search, \PhpOffice\PhpWord\Element\AbstractElement $chart)
+    public function setChart($search, \Shareforce\PhpWord\Element\AbstractElement $chart)
     {
         $elementName = substr(get_class($chart), strrpos(get_class($chart), '\\') + 1);
-        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
+        $objectClass = 'Shareforce\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
 
         // Get the next relation id
         $rId = $this->getNextRelationsIndex($this->getMainPartName());
@@ -373,7 +373,7 @@ class TemplateProcessor
         $filename = "charts/chart{$rId}.xml";
 
         // Get the part writer
-        $writerPart = new \PhpOffice\PhpWord\Writer\Word2007\Part\Chart();
+        $writerPart = new \Shareforce\PhpWord\Writer\Word2007\Part\Chart();
         $writerPart->setElement($chart);
 
         // ContentTypes.xml
@@ -718,7 +718,7 @@ class TemplateProcessor
      * @param string $search
      * @param int $numberOfClones
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      */
     public function cloneRow($search, $numberOfClones)
     {
@@ -883,7 +883,7 @@ class TemplateProcessor
     /**
      * Saves the result document.
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return string
      */
@@ -1093,7 +1093,7 @@ class TemplateProcessor
      *
      * @param int $offset
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
      * @return int
      */
@@ -1187,7 +1187,7 @@ class TemplateProcessor
      * @param string $macro Name of macro
      * @param string $block New block content
      * @param string $blockType XML tag type of block
-     * @return \PhpOffice\PhpWord\TemplateProcessor Fluent interface
+     * @return \Shareforce\PhpWord\TemplateProcessor Fluent interface
      */
     public function replaceXmlBlock($macro, $block, $blockType = 'w:p')
     {

--- a/src/PhpWord/Writer/AbstractWriter.php
+++ b/src/PhpWord/Writer/AbstractWriter.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\Exception\CopyFileException;
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\ZipArchive;
+use Shareforce\PhpWord\Exception\CopyFileException;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\ZipArchive;
 
 /**
  * Abstract writer class
@@ -33,7 +33,7 @@ abstract class AbstractWriter implements WriterInterface
     /**
      * PHPWord object
      *
-     * @var \PhpOffice\PhpWord\PhpWord
+     * @var \Shareforce\PhpWord\PhpWord
      */
     protected $phpWord = null;
 
@@ -96,8 +96,8 @@ abstract class AbstractWriter implements WriterInterface
     /**
      * Get PhpWord object
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
-     * @return \PhpOffice\PhpWord\PhpWord
+     * @throws \Shareforce\PhpWord\Exception\Exception
+     * @return \Shareforce\PhpWord\PhpWord
      */
     public function getPhpWord()
     {
@@ -110,7 +110,7 @@ abstract class AbstractWriter implements WriterInterface
     /**
      * Set PhpWord object
      *
-     * @param \PhpOffice\PhpWord\PhpWord
+     * @param \Shareforce\PhpWord\PhpWord
      * @return self
      */
     public function setPhpWord(PhpWord $phpWord = null)
@@ -151,7 +151,7 @@ abstract class AbstractWriter implements WriterInterface
      * @param bool $value
      * @param string $directory
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      * @return self
      */
     public function setUseDiskCaching($value = false, $directory = null)
@@ -234,7 +234,7 @@ abstract class AbstractWriter implements WriterInterface
     /**
      * Cleanup temporary file.
      *
-     * @throws \PhpOffice\PhpWord\Exception\CopyFileException
+     * @throws \Shareforce\PhpWord\Exception\CopyFileException
      */
     protected function cleanupTempFile()
     {
@@ -268,7 +268,7 @@ abstract class AbstractWriter implements WriterInterface
      *
      * @throws \Exception
      *
-     * @return \PhpOffice\PhpWord\Shared\ZipArchive
+     * @return \Shareforce\PhpWord\Shared\ZipArchive
      */
     protected function getZipArchive($filename)
     {
@@ -335,7 +335,7 @@ abstract class AbstractWriter implements WriterInterface
     /**
      * Add files to package.
      *
-     * @param \PhpOffice\PhpWord\Shared\ZipArchive $zip
+     * @param \Shareforce\PhpWord\Shared\ZipArchive $zip
      * @param mixed $elements
      */
     protected function addFilesToPackage(ZipArchive $zip, $elements)
@@ -373,7 +373,7 @@ abstract class AbstractWriter implements WriterInterface
      *
      * Get the actual source from an archive image.
      *
-     * @param \PhpOffice\PhpWord\Shared\ZipArchive $zipPackage
+     * @param \Shareforce\PhpWord\Shared\ZipArchive $zipPackage
      * @param string $source
      * @param string $target
      */

--- a/src/PhpWord/Writer/HTML.php
+++ b/src/PhpWord/Writer/HTML.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\PhpWord;
+use Shareforce\PhpWord\PhpWord;
 
 /**
  * HTML writer
@@ -50,9 +50,9 @@ class HTML extends AbstractWriter implements WriterInterface
 
         $this->parts = array('Head', 'Body');
         foreach ($this->parts as $partName) {
-            $partClass = 'PhpOffice\\PhpWord\\Writer\\HTML\\Part\\' . $partName;
+            $partClass = 'Shareforce\\PhpWord\\Writer\\HTML\\Part\\' . $partName;
             if (class_exists($partClass)) {
-                /** @var \PhpOffice\PhpWord\Writer\HTML\Part\AbstractPart $part Type hint */
+                /** @var \Shareforce\PhpWord\Writer\HTML\Part\AbstractPart $part Type hint */
                 $part = new $partClass();
                 $part->setParentWriter($this);
                 $this->writerParts[strtolower($partName)] = $part;
@@ -65,7 +65,7 @@ class HTML extends AbstractWriter implements WriterInterface
      *
      * @param string $filename
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      */
     public function save($filename = null)
     {

--- a/src/PhpWord/Writer/HTML/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/HTML/Element/AbstractElement.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 use Laminas\Escaper\Escaper;
-use PhpOffice\PhpWord\Element\AbstractElement as Element;
-use PhpOffice\PhpWord\Writer\AbstractWriter;
+use Shareforce\PhpWord\Element\AbstractElement as Element;
+use Shareforce\PhpWord\Writer\AbstractWriter;
 
 /**
  * Abstract HTML element writer
@@ -31,14 +31,14 @@ abstract class AbstractElement
     /**
      * Parent writer
      *
-     * @var \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @var \Shareforce\PhpWord\Writer\AbstractWriter
      */
     protected $parentWriter;
 
     /**
      * Element
      *
-     * @var \PhpOffice\PhpWord\Element\AbstractElement
+     * @var \Shareforce\PhpWord\Element\AbstractElement
      */
     protected $element;
 
@@ -50,7 +50,7 @@ abstract class AbstractElement
     protected $withoutP = false;
 
     /**
-     * @var \Laminas\Escaper\Escaper|\PhpOffice\PhpWord\Escaper\AbstractEscaper
+     * @var \Laminas\Escaper\Escaper|\Shareforce\PhpWord\Escaper\AbstractEscaper
      */
     protected $escaper;
 
@@ -62,8 +62,8 @@ abstract class AbstractElement
     /**
      * Create new instance
      *
-     * @param \PhpOffice\PhpWord\Writer\AbstractWriter $parentWriter
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $element
+     * @param \Shareforce\PhpWord\Writer\AbstractWriter $parentWriter
+     * @param \Shareforce\PhpWord\Element\AbstractElement $element
      * @param bool $withoutP
      */
     public function __construct(AbstractWriter $parentWriter, Element $element, $withoutP = false)

--- a/src/PhpWord/Writer/HTML/Element/Bookmark.php
+++ b/src/PhpWord/Writer/HTML/Element/Bookmark.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * Bookmark element HTML writer
@@ -31,7 +31,7 @@ class Bookmark extends Text
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\Bookmark) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\Bookmark) {
             return '';
         }
 

--- a/src/PhpWord/Writer/HTML/Element/Container.php
+++ b/src/PhpWord/Writer/HTML/Element/Container.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
-use PhpOffice\PhpWord\Element\AbstractContainer as ContainerElement;
+use Shareforce\PhpWord\Element\AbstractContainer as ContainerElement;
 
 /**
  * Container element HTML writer
@@ -31,7 +31,7 @@ class Container extends AbstractElement
      *
      * @var string
      */
-    protected $namespace = 'PhpOffice\\PhpWord\\Writer\\HTML\\Element';
+    protected $namespace = 'Shareforce\\PhpWord\\Writer\\HTML\\Element';
 
     /**
      * Write container
@@ -51,9 +51,9 @@ class Container extends AbstractElement
         $elements = $container->getElements();
         foreach ($elements as $element) {
             $elementClass = get_class($element);
-            $writerClass = str_replace('PhpOffice\\PhpWord\\Element', $this->namespace, $elementClass);
+            $writerClass = str_replace('Shareforce\\PhpWord\\Element', $this->namespace, $elementClass);
             if (class_exists($writerClass)) {
-                /** @var \PhpOffice\PhpWord\Writer\HTML\Element\AbstractElement $writer Type hint */
+                /** @var \Shareforce\PhpWord\Writer\HTML\Element\AbstractElement $writer Type hint */
                 $writer = new $writerClass($this->parentWriter, $element, $withoutP);
                 $content .= $writer->write();
             }

--- a/src/PhpWord/Writer/HTML/Element/Endnote.php
+++ b/src/PhpWord/Writer/HTML/Element/Endnote.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * Endnote element HTML writer

--- a/src/PhpWord/Writer/HTML/Element/Footnote.php
+++ b/src/PhpWord/Writer/HTML/Element/Footnote.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * Footnote element HTML writer
@@ -38,10 +38,10 @@ class Footnote extends AbstractElement
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\Footnote) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\Footnote) {
             return '';
         }
-        /** @var \PhpOffice\PhpWord\Writer\HTML $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\HTML $parentWriter Type hint */
         $parentWriter = $this->parentWriter;
 
         $noteId = count($parentWriter->getNotes()) + 1;

--- a/src/PhpWord/Writer/HTML/Element/Image.php
+++ b/src/PhpWord/Writer/HTML/Element/Image.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
-use PhpOffice\PhpWord\Element\Image as ImageElement;
-use PhpOffice\PhpWord\Writer\HTML\Style\Image as ImageStyleWriter;
+use Shareforce\PhpWord\Element\Image as ImageElement;
+use Shareforce\PhpWord\Writer\HTML\Style\Image as ImageStyleWriter;
 
 /**
  * Image element HTML writer

--- a/src/PhpWord/Writer/HTML/Element/Link.php
+++ b/src/PhpWord/Writer/HTML/Element/Link.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Settings;
 
 /**
  * Link element HTML writer
@@ -33,7 +33,7 @@ class Link extends Text
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\Link) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\Link) {
             return '';
         }
 

--- a/src/PhpWord/Writer/HTML/Element/ListItem.php
+++ b/src/PhpWord/Writer/HTML/Element/ListItem.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Settings;
 
 /**
  * ListItem element HTML writer
@@ -33,7 +33,7 @@ class ListItem extends AbstractElement
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\ListItem) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\ListItem) {
             return '';
         }
 

--- a/src/PhpWord/Writer/HTML/Element/ListItemRun.php
+++ b/src/PhpWord/Writer/HTML/Element/ListItemRun.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * ListItem element HTML writer
@@ -31,7 +31,7 @@ class ListItemRun extends TextRun
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\ListItemRun) {
             return '';
         }
 

--- a/src/PhpWord/Writer/HTML/Element/PageBreak.php
+++ b/src/PhpWord/Writer/HTML/Element/PageBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * PageBreak element HTML writer
@@ -33,7 +33,7 @@ class PageBreak extends TextBreak
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Writer\HTML $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\HTML $parentWriter Type hint */
         $parentWriter = $this->parentWriter;
         if ($parentWriter->isPdf()) {
             return '<pagebreak style="page-break-before: always;" pagebreak="true"></pagebreak>';

--- a/src/PhpWord/Writer/HTML/Element/Table.php
+++ b/src/PhpWord/Writer/HTML/Element/Table.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * Table element HTML writer
@@ -31,7 +31,7 @@ class Table extends AbstractElement
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\Table) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\Table) {
             return '';
         }
 
@@ -42,7 +42,7 @@ class Table extends AbstractElement
             $content .= '<table' . self::getTableStyle($this->element->getStyle()) . '>' . PHP_EOL;
 
             for ($i = 0; $i < $rowCount; $i++) {
-                /** @var $row \PhpOffice\PhpWord\Element\Row Type hint */
+                /** @var $row \Shareforce\PhpWord\Element\Row Type hint */
                 $rowStyle = $rows[$i]->getStyle();
                 // $height = $row->getHeight();
                 $tblHeader = $rowStyle->isTblHeader();
@@ -118,7 +118,7 @@ class Table extends AbstractElement
     /**
      * Translates Table style in CSS equivalent
      *
-     * @param string|\PhpOffice\PhpWord\Style\Table|null $tableStyle
+     * @param string|\Shareforce\PhpWord\Style\Table|null $tableStyle
      * @return string
      */
     private function getTableStyle($tableStyle = null)
@@ -130,9 +130,9 @@ class Table extends AbstractElement
             $style = ' class="' . $tableStyle;
         } else {
             $style = ' style="';
-            if ($tableStyle->getLayout() == \PhpOffice\PhpWord\Style\Table::LAYOUT_FIXED) {
+            if ($tableStyle->getLayout() == \Shareforce\PhpWord\Style\Table::LAYOUT_FIXED) {
                 $style .= 'table-layout: fixed;';
-            } elseif ($tableStyle->getLayout() == \PhpOffice\PhpWord\Style\Table::LAYOUT_AUTO) {
+            } elseif ($tableStyle->getLayout() == \Shareforce\PhpWord\Style\Table::LAYOUT_AUTO) {
                 $style .= 'table-layout: auto;';
             }
         }

--- a/src/PhpWord/Writer/HTML/Element/Text.php
+++ b/src/PhpWord/Writer/HTML/Element/Text.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
-use PhpOffice\PhpWord\Writer\HTML\Style\Font as FontStyleWriter;
-use PhpOffice\PhpWord\Writer\HTML\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Writer\HTML\Style\Font as FontStyleWriter;
+use Shareforce\PhpWord\Writer\HTML\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * Text element HTML writer
@@ -66,7 +66,7 @@ class Text extends AbstractElement
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
         $this->getFontStyle();
 
@@ -217,7 +217,7 @@ class Text extends AbstractElement
      */
     private function getParagraphStyle()
     {
-        /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
         $style = '';
         if (!method_exists($element, 'getParagraphStyle')) {
@@ -245,7 +245,7 @@ class Text extends AbstractElement
      */
     private function getFontStyle()
     {
-        /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
         $style = '';
         $fontStyle = $element->getFontStyle();

--- a/src/PhpWord/Writer/HTML/Element/TextBreak.php
+++ b/src/PhpWord/Writer/HTML/Element/TextBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * TextBreak element HTML writer

--- a/src/PhpWord/Writer/HTML/Element/TextRun.php
+++ b/src/PhpWord/Writer/HTML/Element/TextRun.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
 /**
  * TextRun element HTML writer

--- a/src/PhpWord/Writer/HTML/Element/Title.php
+++ b/src/PhpWord/Writer/HTML/Element/Title.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Element;
+namespace Shareforce\PhpWord\Writer\HTML\Element;
 
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Settings;
 
 /**
  * TextRun element HTML writer
@@ -33,7 +33,7 @@ class Title extends AbstractElement
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\Title) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\Title) {
             return '';
         }
 
@@ -44,7 +44,7 @@ class Title extends AbstractElement
             if (Settings::isOutputEscapingEnabled()) {
                 $text = $this->escaper->escapeHtml($text);
             }
-        } elseif ($text instanceof \PhpOffice\PhpWord\Element\AbstractContainer) {
+        } elseif ($text instanceof \Shareforce\PhpWord\Element\AbstractContainer) {
             $writer = new Container($this->parentWriter, $text);
             $text = $writer->write();
         }

--- a/src/PhpWord/Writer/HTML/Part/AbstractPart.php
+++ b/src/PhpWord/Writer/HTML/Part/AbstractPart.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Part;
+namespace Shareforce\PhpWord\Writer\HTML\Part;
 
 use Laminas\Escaper\Escaper;
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\Writer\AbstractWriter;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Writer\AbstractWriter;
 
 /**
  * @since 0.11.0
@@ -27,7 +27,7 @@ use PhpOffice\PhpWord\Writer\AbstractWriter;
 abstract class AbstractPart
 {
     /**
-     * @var \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @var \Shareforce\PhpWord\Writer\AbstractWriter
      */
     private $parentWriter;
 
@@ -47,7 +47,7 @@ abstract class AbstractPart
     abstract public function write();
 
     /**
-     * @param \PhpOffice\PhpWord\Writer\AbstractWriter $writer
+     * @param \Shareforce\PhpWord\Writer\AbstractWriter $writer
      */
     public function setParentWriter(AbstractWriter $writer = null)
     {
@@ -55,9 +55,9 @@ abstract class AbstractPart
     }
 
     /**
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      *
-     * @return \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @return \Shareforce\PhpWord\Writer\AbstractWriter
      */
     public function getParentWriter()
     {

--- a/src/PhpWord/Writer/HTML/Part/Body.php
+++ b/src/PhpWord/Writer/HTML/Part/Body.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Part;
+namespace Shareforce\PhpWord\Writer\HTML\Part;
 
-use PhpOffice\PhpWord\Writer\HTML\Element\Container;
-use PhpOffice\PhpWord\Writer\HTML\Element\TextRun as TextRunWriter;
+use Shareforce\PhpWord\Writer\HTML\Element\Container;
+use Shareforce\PhpWord\Writer\HTML\Element\TextRun as TextRunWriter;
 
 /**
  * RTF body part writer
@@ -58,7 +58,7 @@ class Body extends AbstractPart
      */
     private function writeNotes()
     {
-        /** @var \PhpOffice\PhpWord\Writer\HTML $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\HTML $parentWriter Type hint */
         $parentWriter = $this->getParentWriter();
         $phpWord = $parentWriter->getPhpWord();
         $notes = $parentWriter->getNotes();

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Part;
+namespace Shareforce\PhpWord\Writer\HTML\Part;
 
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
-use PhpOffice\PhpWord\Writer\HTML\Style\Font as FontStyleWriter;
-use PhpOffice\PhpWord\Writer\HTML\Style\Generic as GenericStyleWriter;
-use PhpOffice\PhpWord\Writer\HTML\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Writer\HTML\Style\Font as FontStyleWriter;
+use Shareforce\PhpWord\Writer\HTML\Style\Generic as GenericStyleWriter;
+use Shareforce\PhpWord\Writer\HTML\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * RTF head part writer

--- a/src/PhpWord/Writer/HTML/Style/AbstractStyle.php
+++ b/src/PhpWord/Writer/HTML/Style/AbstractStyle.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Style;
+namespace Shareforce\PhpWord\Writer\HTML\Style;
 
-use PhpOffice\PhpWord\Style\AbstractStyle as Style;
+use Shareforce\PhpWord\Style\AbstractStyle as Style;
 
 /**
  * Style writer
@@ -29,14 +29,14 @@ abstract class AbstractStyle
     /**
      * Parent writer
      *
-     * @var \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @var \Shareforce\PhpWord\Writer\AbstractWriter
      */
     private $parentWriter;
 
     /**
      * Style
      *
-     * @var array|\PhpOffice\PhpWord\Style\AbstractStyle
+     * @var array|\Shareforce\PhpWord\Style\AbstractStyle
      */
     private $style;
 
@@ -48,7 +48,7 @@ abstract class AbstractStyle
     /**
      * Create new instance
      *
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $style
+     * @param array|\Shareforce\PhpWord\Style\AbstractStyle $style
      */
     public function __construct($style = null)
     {
@@ -58,7 +58,7 @@ abstract class AbstractStyle
     /**
      * Set parent writer.
      *
-     * @param \PhpOffice\PhpWord\Writer\AbstractWriter $writer
+     * @param \Shareforce\PhpWord\Writer\AbstractWriter $writer
      */
     public function setParentWriter($writer)
     {
@@ -68,7 +68,7 @@ abstract class AbstractStyle
     /**
      * Get parent writer
      *
-     * @return \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @return \Shareforce\PhpWord\Writer\AbstractWriter
      */
     public function getParentWriter()
     {
@@ -78,7 +78,7 @@ abstract class AbstractStyle
     /**
      * Get style
      *
-     * @return array|\PhpOffice\PhpWord\Style\AbstractStyle $style
+     * @return array|\Shareforce\PhpWord\Style\AbstractStyle $style
      */
     public function getStyle()
     {

--- a/src/PhpWord/Writer/HTML/Style/Font.php
+++ b/src/PhpWord/Writer/HTML/Style/Font.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Style;
+namespace Shareforce\PhpWord\Writer\HTML\Style;
 
-use PhpOffice\PhpWord\Style\Font as FontStyle;
+use Shareforce\PhpWord\Style\Font as FontStyle;
 
 /**
  * Font style HTML writer

--- a/src/PhpWord/Writer/HTML/Style/Generic.php
+++ b/src/PhpWord/Writer/HTML/Style/Generic.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Style;
+namespace Shareforce\PhpWord\Writer\HTML\Style;
 
 /**
  * Generic style writer

--- a/src/PhpWord/Writer/HTML/Style/Image.php
+++ b/src/PhpWord/Writer/HTML/Style/Image.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Style;
+namespace Shareforce\PhpWord\Writer\HTML\Style;
 
 /**
  * Paragraph style HTML writer
@@ -32,7 +32,7 @@ class Image extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Image) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Image) {
             return '';
         }
         $css = array();

--- a/src/PhpWord/Writer/HTML/Style/Paragraph.php
+++ b/src/PhpWord/Writer/HTML/Style/Paragraph.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML\Style;
+namespace Shareforce\PhpWord\Writer\HTML\Style;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
  * Paragraph style HTML writer
@@ -34,7 +34,7 @@ class Paragraph extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Paragraph) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Paragraph) {
             return '';
         }
         $css = array();

--- a/src/PhpWord/Writer/ODText.php
+++ b/src/PhpWord/Writer/ODText.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\Media;
-use PhpOffice\PhpWord\PhpWord;
+use Shareforce\PhpWord\Media;
+use Shareforce\PhpWord\PhpWord;
 
 /**
  * ODText writer
@@ -30,7 +30,7 @@ class ODText extends AbstractWriter implements WriterInterface
     /**
      * Create new ODText writer
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function __construct(PhpWord $phpWord = null)
     {
@@ -48,7 +48,7 @@ class ODText extends AbstractWriter implements WriterInterface
         foreach (array_keys($this->parts) as $partName) {
             $partClass = get_class($this) . '\\Part\\' . $partName;
             if (class_exists($partClass)) {
-                /** @var $partObject \PhpOffice\PhpWord\Writer\ODText\Part\AbstractPart Type hint */
+                /** @var $partObject \Shareforce\PhpWord\Writer\ODText\Part\AbstractPart Type hint */
                 $partObject = new $partClass();
                 $partObject->setParentWriter($this);
                 $this->writerParts[strtolower($partName)] = $partObject;

--- a/src/PhpWord/Writer/ODText/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/ODText/Element/AbstractElement.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
-use PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement as Word2007AbstractElement;
+use Shareforce\PhpWord\Writer\Word2007\Element\AbstractElement as Word2007AbstractElement;
 
 /**
  * Abstract element writer

--- a/src/PhpWord/Writer/ODText/Element/Container.php
+++ b/src/PhpWord/Writer/ODText/Element/Container.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
-use PhpOffice\PhpWord\Writer\Word2007\Element\Container as Word2007Container;
+use Shareforce\PhpWord\Writer\Word2007\Element\Container as Word2007Container;
 
 /**
  * Container element writer (section, textrun, header, footnote, cell, etc.)
@@ -31,5 +31,5 @@ class Container extends Word2007Container
      *
      * @var string
      */
-    protected $namespace = 'PhpOffice\\PhpWord\\Writer\\ODText\\Element';
+    protected $namespace = 'Shareforce\\PhpWord\\Writer\\ODText\\Element';
 }

--- a/src/PhpWord/Writer/ODText/Element/Field.php
+++ b/src/PhpWord/Writer/ODText/Element/Field.php
@@ -20,7 +20,7 @@
 //     - supports style only if specified by name
 //     - spaces before and after field may be dropped
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
 /**
  * Field element writer
@@ -35,7 +35,7 @@ class Field extends Text
     public function write()
     {
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Field) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Field) {
             return;
         }
 
@@ -49,7 +49,7 @@ class Field extends Text
         }
     }
 
-    private function writeDefault(\PhpOffice\PhpWord\Element\Field $element, $type)
+    private function writeDefault(\Shareforce\PhpWord\Element\Field $element, $type)
     {
         $xmlWriter = $this->getXmlWriter();
 

--- a/src/PhpWord/Writer/ODText/Element/Image.php
+++ b/src/PhpWord/Writer/ODText/Element/Image.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
-use PhpOffice\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Shared\Converter;
 
 /**
  * Image element writer
@@ -33,7 +33,7 @@ class Image extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Image) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Image) {
             return;
         }
 

--- a/src/PhpWord/Writer/ODText/Element/Link.php
+++ b/src/PhpWord/Writer/ODText/Element/Link.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
 /**
  * Text element writer
@@ -31,7 +31,7 @@ class Link extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Link) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Link) {
             return;
         }
 

--- a/src/PhpWord/Writer/ODText/Element/PageBreak.php
+++ b/src/PhpWord/Writer/ODText/Element/PageBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
 /**
  * PageBreak element writer

--- a/src/PhpWord/Writer/ODText/Element/Table.php
+++ b/src/PhpWord/Writer/ODText/Element/Table.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
-use PhpOffice\PhpWord\Element\Row as RowElement;
-use PhpOffice\PhpWord\Element\Table as TableElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Element\Row as RowElement;
+use Shareforce\PhpWord\Element\Table as TableElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Table element writer
@@ -35,7 +35,7 @@ class Table extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Table) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Table) {
             return;
         }
         $rows = $element->getRows();
@@ -60,8 +60,8 @@ class Table extends AbstractElement
     /**
      * Write column.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Table $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Table $element
      */
     private function writeColumns(XMLWriter $xmlWriter, TableElement $element)
     {
@@ -77,13 +77,13 @@ class Table extends AbstractElement
     /**
      * Write row.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Row $row
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Row $row
      */
     private function writeRow(XMLWriter $xmlWriter, RowElement $row)
     {
         $xmlWriter->startElement('table:table-row');
-        /** @var $row \PhpOffice\PhpWord\Element\Row Type hint */
+        /** @var $row \Shareforce\PhpWord\Element\Row Type hint */
         foreach ($row->getCells() as $cell) {
             $xmlWriter->startElement('table:table-cell');
             $xmlWriter->writeAttribute('office:value-type', 'string');

--- a/src/PhpWord/Writer/ODText/Element/Text.php
+++ b/src/PhpWord/Writer/ODText/Element/Text.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\Exception\Exception;
 
 /**
  * Text element writer
@@ -34,7 +34,7 @@ class Text extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Text) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Text) {
             return;
         }
         $fontStyle = $element->getFontStyle();

--- a/src/PhpWord/Writer/ODText/Element/TextBreak.php
+++ b/src/PhpWord/Writer/ODText/Element/TextBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
 /**
  * TextBreak element writer

--- a/src/PhpWord/Writer/ODText/Element/TextRun.php
+++ b/src/PhpWord/Writer/ODText/Element/TextRun.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
 /**
  * TextRun element writer

--- a/src/PhpWord/Writer/ODText/Element/Title.php
+++ b/src/PhpWord/Writer/ODText/Element/Title.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Element;
+namespace Shareforce\PhpWord\Writer\ODText\Element;
 
 /**
  * Title element writer
@@ -31,14 +31,14 @@ class Title extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Title) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Title) {
             return;
         }
 
         $xmlWriter->startElement('text:h');
         $hdname = 'HD';
         $sect = $element->getParent();
-        if ($sect instanceof \PhpOffice\PhpWord\Element\Section) {
+        if ($sect instanceof \Shareforce\PhpWord\Element\Section) {
             if (self::compareToFirstElement($element, $sect->getElements())) {
                 $hdname = 'HE';
             }
@@ -55,7 +55,7 @@ class Title extends AbstractElement
         $text = $element->getText();
         if (is_string($text)) {
             $this->writeText($text);
-        } elseif ($text instanceof \PhpOffice\PhpWord\Element\AbstractContainer) {
+        } elseif ($text instanceof \Shareforce\PhpWord\Element\AbstractContainer) {
             $containerWriter = new Container($xmlWriter, $text);
             $containerWriter->write();
         }
@@ -66,9 +66,9 @@ class Title extends AbstractElement
     /**
      * Test if element is same as first element in array
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $elem
+     * @param \Shareforce\PhpWord\Element\AbstractElement $elem
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractElement[] $elemarray
+     * @param \Shareforce\PhpWord\Element\AbstractElement[] $elemarray
      *
      * @return bool
      */

--- a/src/PhpWord/Writer/ODText/Part/AbstractPart.php
+++ b/src/PhpWord/Writer/ODText/Part/AbstractPart.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Writer\Word2007\Part\AbstractPart as Word2007AbstractPart;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Writer\Word2007\Part\AbstractPart as Word2007AbstractPart;
 
 /**
  * ODText writer part abstract
@@ -36,7 +36,7 @@ abstract class AbstractPart extends Word2007AbstractPart
     /**
      * Write common root attributes.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     protected function writeCommonRootAttributes(XMLWriter $xmlWriter)
     {
@@ -72,7 +72,7 @@ abstract class AbstractPart extends Word2007AbstractPart
     /**
      * Write font faces declaration.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     protected function writeFontFaces(XMLWriter $xmlWriter)
     {

--- a/src/PhpWord/Writer/ODText/Part/Content.php
+++ b/src/PhpWord/Writer/ODText/Part/Content.php
@@ -15,23 +15,23 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
-use PhpOffice\PhpWord\Element\AbstractContainer;
-use PhpOffice\PhpWord\Element\Field;
-use PhpOffice\PhpWord\Element\Image;
-use PhpOffice\PhpWord\Element\Table;
-use PhpOffice\PhpWord\Element\Text;
-use PhpOffice\PhpWord\Element\TextRun;
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
-use PhpOffice\PhpWord\Style\Table as TableStyle;
-use PhpOffice\PhpWord\Writer\ODText\Element\Container;
-use PhpOffice\PhpWord\Writer\ODText\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Element\AbstractContainer;
+use Shareforce\PhpWord\Element\Field;
+use Shareforce\PhpWord\Element\Image;
+use Shareforce\PhpWord\Element\Table;
+use Shareforce\PhpWord\Element\Text;
+use Shareforce\PhpWord\Element\TextRun;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Style\Table as TableStyle;
+use Shareforce\PhpWord\Writer\ODText\Element\Container;
+use Shareforce\PhpWord\Writer\ODText\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * ODText content part writer: content.xml
@@ -151,7 +151,7 @@ class Content extends AbstractPart
      *
      * @since 0.11.0
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writeAutoStyles(XMLWriter $xmlWriter)
     {
@@ -159,9 +159,9 @@ class Content extends AbstractPart
 
         $this->writeTextStyles($xmlWriter);
         foreach ($this->autoStyles as $element => $styles) {
-            $writerClass = 'PhpOffice\\PhpWord\\Writer\\ODText\\Style\\' . $element;
+            $writerClass = 'Shareforce\\PhpWord\\Writer\\ODText\\Style\\' . $element;
             foreach ($styles as $style) {
-                /** @var \PhpOffice\PhpWord\Writer\ODText\Style\AbstractStyle $styleWriter Type hint */
+                /** @var \Shareforce\PhpWord\Writer\ODText\Style\AbstractStyle $styleWriter Type hint */
                 $styleWriter = new $writerClass($xmlWriter, $style);
                 $styleWriter->write();
             }
@@ -173,7 +173,7 @@ class Content extends AbstractPart
     /**
      * Write automatic styles.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writeTextStyles(XMLWriter $xmlWriter)
     {
@@ -219,7 +219,7 @@ class Content extends AbstractPart
             if ($style->isAuto() === true) {
                 $styleClass = str_replace('\\Style\\', '\\Writer\\ODText\\Style\\', get_class($style));
                 if (class_exists($styleClass)) {
-                    /** @var \PhpOffice\PhpWord\Writer\ODText\Style\AbstractStyle $styleWriter Type hint */
+                    /** @var \Shareforce\PhpWord\Writer\ODText\Style\AbstractStyle $styleWriter Type hint */
                     $styleWriter = new $styleClass($xmlWriter, $style);
                     $styleWriter->write();
                 }
@@ -229,7 +229,7 @@ class Content extends AbstractPart
             }
         }
         foreach ($this->imageParagraphStyles as $style) {
-            $styleWriter = new \PhpOffice\PhpWord\Writer\ODText\Style\Paragraph($xmlWriter, $style);
+            $styleWriter = new \Shareforce\PhpWord\Writer\ODText\Style\Paragraph($xmlWriter, $style);
             $styleWriter->write();
         }
     }
@@ -237,7 +237,7 @@ class Content extends AbstractPart
     /**
      * Get automatic styles.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     private function getAutoStyles(PhpWord $phpWord)
     {
@@ -257,7 +257,7 @@ class Content extends AbstractPart
      *
      * Table style can be null or string of the style name
      *
-     * @param \PhpOffice\PhpWord\Element\AbstractContainer $container
+     * @param \Shareforce\PhpWord\Element\AbstractContainer $container
      * @param int $paragraphStyleCount
      * @param int $fontStyleCount
      * @todo Simplify the logic
@@ -277,13 +277,13 @@ class Content extends AbstractPart
                 $style = $element->getStyle();
                 $style->setStyleName('fr' . $element->getMediaIndex());
                 $this->autoStyles['Image'][] = $style;
-                $sty = new \PhpOffice\PhpWord\Style\Paragraph();
+                $sty = new \Shareforce\PhpWord\Style\Paragraph();
                 $sty->setStyleName('IM' . $element->getMediaIndex());
                 $sty->setAuto();
                 $sty->setAlignment($style->getAlignment());
                 $this->imageParagraphStyles[] = $sty;
             } elseif ($element instanceof Table) {
-                /** @var \PhpOffice\PhpWord\Style\Table $style */
+                /** @var \Shareforce\PhpWord\Style\Table $style */
                 $style = $element->getStyle();
                 if (is_string($style)) {
                     $style = Style::getStyle($style);
@@ -301,7 +301,7 @@ class Content extends AbstractPart
     /**
      * Get style of individual element
      *
-     * @param \PhpOffice\PhpWord\Element\Text $element
+     * @param \Shareforce\PhpWord\Element\Text $element
      * @param int $paragraphStyleCount
      * @param int $fontStyleCount
      */
@@ -347,7 +347,7 @@ class Content extends AbstractPart
     /**
      * Get font style of individual field element
      *
-     * @param \PhpOffice\PhpWord\Element\Field $element
+     * @param \Shareforce\PhpWord\Element\Field $element
      * @param int $paragraphStyleCount
      * @param int $fontStyleCount
      */
@@ -373,7 +373,7 @@ class Content extends AbstractPart
     /**
      * Get style of individual element
      *
-     * @param \PhpOffice\PhpWord\Element\TextRun $element
+     * @param \Shareforce\PhpWord\Element\TextRun $element
      * @param int $paragraphStyleCount
      */
     private function getElementStyleTextRun($element, &$paragraphStyleCount)
@@ -405,7 +405,7 @@ class Content extends AbstractPart
      * Finds all tracked changes
      *
      * @param AbstractContainer $container
-     * @param \PhpOffice\PhpWord\Element\AbstractElement[] $trackedChanges
+     * @param \Shareforce\PhpWord\Element\AbstractElement[] $trackedChanges
      */
     private function collectTrackedChanges(AbstractContainer $container, &$trackedChanges = array())
     {

--- a/src/PhpWord/Writer/ODText/Part/Manifest.php
+++ b/src/PhpWord/Writer/ODText/Part/Manifest.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
-use PhpOffice\PhpWord\Media;
+use Shareforce\PhpWord\Media;
 
 /**
  * ODText manifest part writer: META-INF/manifest.xml

--- a/src/PhpWord/Writer/ODText/Part/Meta.php
+++ b/src/PhpWord/Writer/ODText/Part/Meta.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * ODText meta part writer: meta.xml
@@ -86,7 +86,7 @@ class Meta extends AbstractPart
     /**
      * Write individual property
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $property
      * @param string $value
      *

--- a/src/PhpWord/Writer/ODText/Part/Mimetype.php
+++ b/src/PhpWord/Writer/ODText/Part/Mimetype.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
 /**
  * ODText mimetype part writer: mimetype

--- a/src/PhpWord/Writer/ODText/Part/Styles.php
+++ b/src/PhpWord/Writer/ODText/Part/Styles.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\Converter;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style;
 
 /**
  * ODText styles part writer: styles.xml
@@ -66,7 +66,7 @@ class Styles extends AbstractPart
     /**
      * Write default styles.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writeDefault(XMLWriter $xmlWriter)
     {
@@ -118,7 +118,7 @@ class Styles extends AbstractPart
     /**
      * Write named styles.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writeNamed(XMLWriter $xmlWriter)
     {
@@ -128,7 +128,7 @@ class Styles extends AbstractPart
                 if ($style->isAuto() === false) {
                     $styleClass = str_replace('\\Style\\', '\\Writer\\ODText\\Style\\', get_class($style));
                     if (class_exists($styleClass)) {
-                        /** @var $styleWriter \PhpOffice\PhpWord\Writer\ODText\Style\AbstractStyle Type hint */
+                        /** @var $styleWriter \Shareforce\PhpWord\Writer\ODText\Style\AbstractStyle Type hint */
                         $styleWriter = new $styleClass($xmlWriter, $style);
                         $styleWriter->write();
                     }
@@ -155,7 +155,7 @@ class Styles extends AbstractPart
     /**
      * call writePageLayoutIndiv to write page layout styles for each page
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writePageLayout(XMLWriter $xmlWriter)
     {
@@ -169,8 +169,8 @@ class Styles extends AbstractPart
     /**
      * Write page layout styles.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Section $section
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Section $section
      * @param int $sectionNbr
      */
     private function writePageLayoutIndiv(XMLWriter $xmlWriter, $section, $sectionNbr)
@@ -255,7 +255,7 @@ class Styles extends AbstractPart
     /**
      * Write master style.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writeMaster(XMLWriter $xmlWriter)
     {

--- a/src/PhpWord/Writer/ODText/Style/AbstractStyle.php
+++ b/src/PhpWord/Writer/ODText/Style/AbstractStyle.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
-use PhpOffice\PhpWord\Writer\Word2007\Style\AbstractStyle as Word2007AbstractStyle;
+use Shareforce\PhpWord\Writer\Word2007\Style\AbstractStyle as Word2007AbstractStyle;
 
 /**
  * Style writer

--- a/src/PhpWord/Writer/ODText/Style/Font.php
+++ b/src/PhpWord/Writer/ODText/Style/Font.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
 /**
  * Font style writer
@@ -30,16 +30,16 @@ class Font extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Font) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Font) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();
 
         $stylep = (method_exists($style, 'getParagraph')) ? $style->getParagraph() : null;
-        if ($stylep instanceof \PhpOffice\PhpWord\Style\Paragraph) {
+        if ($stylep instanceof \Shareforce\PhpWord\Style\Paragraph) {
             $temp1 = clone $stylep;
             $temp1->setStyleName($style->getStyleName());
-            $temp2 = new \PhpOffice\PhpWord\Writer\ODText\Style\Paragraph($xmlWriter, $temp1);
+            $temp2 = new \Shareforce\PhpWord\Writer\ODText\Style\Paragraph($xmlWriter, $temp1);
             $temp2->write();
         }
 
@@ -61,7 +61,7 @@ class Font extends AbstractStyle
 
         // Color
         $color = $style->getColor();
-        $xmlWriter->writeAttributeIf($color != '', 'fo:color', '#' . \PhpOffice\PhpWord\Shared\Converter::stringToRgb($color));
+        $xmlWriter->writeAttributeIf($color != '', 'fo:color', '#' . \Shareforce\PhpWord\Shared\Converter::stringToRgb($color));
 
         // Bold & italic
         $xmlWriter->writeAttributeIf($style->isBold(), 'fo:font-weight', 'bold');

--- a/src/PhpWord/Writer/ODText/Style/Image.php
+++ b/src/PhpWord/Writer/ODText/Style/Image.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
 /**
  * Image style writer
@@ -29,9 +29,9 @@ class Image extends AbstractStyle
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Style\Image $style Type hint */
+        /** @var \Shareforce\PhpWord\Style\Image $style Type hint */
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Image) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Image) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/ODText/Style/Paragraph.php
+++ b/src/PhpWord/Writer/ODText/Style/Paragraph.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
-use PhpOffice\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Shared\Converter;
 
 /**
  * Font style writer
@@ -32,7 +32,7 @@ class Paragraph extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Paragraph) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Paragraph) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();
@@ -60,13 +60,13 @@ class Paragraph extends AbstractStyle
             } elseif (substr($styleName, 0, 2) === 'HD') {
                 $styleAuto = true;
                 $psm = 'Heading_' . substr($styleName, 2);
-                $stylep = \PhpOffice\PhpWord\Style::getStyle($psm);
-                if ($stylep instanceof \PhpOffice\PhpWord\Style\Font) {
+                $stylep = \Shareforce\PhpWord\Style::getStyle($psm);
+                if ($stylep instanceof \Shareforce\PhpWord\Style\Font) {
                     if (method_exists($stylep, 'getParagraph')) {
                         $stylep = $stylep->getParagraph();
                     }
                 }
-                if ($stylep instanceof \PhpOffice\PhpWord\Style\Paragraph) {
+                if ($stylep instanceof \Shareforce\PhpWord\Style\Paragraph) {
                     if ($stylep->hasPageBreakBefore()) {
                         $breakbefore = true;
                     }
@@ -134,7 +134,7 @@ class Paragraph extends AbstractStyle
 
         //Indentation
         $indent = $style->getIndentation();
-        //if ($indent instanceof \PhpOffice\PhpWord\Style\Indentation) {
+        //if ($indent instanceof \Shareforce\PhpWord\Style\Indentation) {
         if (!empty($indent)) {
             $marg = $indent->getLeft();
             $xmlWriter->writeAttributeIf($marg !== null, 'fo:margin-left', (string) ($marg / Converter::INCH_TO_TWIP) . 'in');

--- a/src/PhpWord/Writer/ODText/Style/Section.php
+++ b/src/PhpWord/Writer/ODText/Style/Section.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
 /**
  * Section style writer
@@ -29,9 +29,9 @@ class Section extends AbstractStyle
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Style\Section $style Type hint */
+        /** @var \Shareforce\PhpWord\Style\Section $style Type hint */
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Section) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Section) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/ODText/Style/Table.php
+++ b/src/PhpWord/Writer/ODText/Style/Table.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
 /**
  * Table style writer
@@ -29,9 +29,9 @@ class Table extends AbstractStyle
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Style\Table $style Type hint */
+        /** @var \Shareforce\PhpWord\Style\Table $style Type hint */
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Table) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Table) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/PDF.php
+++ b/src/PhpWord/Writer/PDF.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
 
 /**
  * PDF Writer
@@ -31,16 +31,16 @@ class PDF
     /**
      * The wrapper for the requested PDF rendering engine
      *
-     * @var \PhpOffice\PhpWord\Writer\PDF\AbstractRenderer
+     * @var \Shareforce\PhpWord\Writer\PDF\AbstractRenderer
      */
     private $renderer = null;
 
     /**
      * Instantiate a new renderer of the configured type within this container class
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      */
     public function __construct(PhpWord $phpWord)
     {

--- a/src/PhpWord/Writer/PDF/AbstractRenderer.php
+++ b/src/PhpWord/Writer/PDF/AbstractRenderer.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\PDF;
+namespace Shareforce\PhpWord\Writer\PDF;
 
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Writer\HTML;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Writer\HTML;
 
 /**
  * Abstract PDF renderer
@@ -78,7 +78,7 @@ abstract class AbstractRenderer extends HTML
      *
      * @param PhpWord $phpWord PhpWord object
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      */
     public function __construct(PhpWord $phpWord)
     {
@@ -175,7 +175,7 @@ abstract class AbstractRenderer extends HTML
      *
      * @param string $filename Name of the file to save as
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      * @return resource
      */
     protected function prepareForSave($filename = null)

--- a/src/PhpWord/Writer/PDF/DomPDF.php
+++ b/src/PhpWord/Writer/PDF/DomPDF.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\PDF;
+namespace Shareforce\PhpWord\Writer\PDF;
 
 use Dompdf\Dompdf as DompdfLib;
-use PhpOffice\PhpWord\Writer\WriterInterface;
+use Shareforce\PhpWord\Writer\WriterInterface;
 
 /**
  * DomPDF writer

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\PDF;
+namespace Shareforce\PhpWord\Writer\PDF;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Writer\WriterInterface;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Writer\WriterInterface;
 
 /**
  * MPDF writer

--- a/src/PhpWord/Writer/PDF/TCPDF.php
+++ b/src/PhpWord/Writer/PDF/TCPDF.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\PDF;
+namespace Shareforce\PhpWord\Writer\PDF;
 
-use PhpOffice\PhpWord\Writer\WriterInterface;
+use Shareforce\PhpWord\Writer\WriterInterface;
 
 /**
  * TCPDF writer

--- a/src/PhpWord/Writer/RTF.php
+++ b/src/PhpWord/Writer/RTF.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\PhpWord;
+use Shareforce\PhpWord\PhpWord;
 
 /**
  * RTF writer
@@ -36,7 +36,7 @@ class RTF extends AbstractWriter implements WriterInterface
     /**
      * Create new instance
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      */
     public function __construct(PhpWord $phpWord = null)
     {
@@ -46,7 +46,7 @@ class RTF extends AbstractWriter implements WriterInterface
         foreach ($this->parts as $partName) {
             $partClass = get_class($this) . '\\Part\\' . $partName;
             if (class_exists($partClass)) {
-                /** @var \PhpOffice\PhpWord\Writer\RTF\Part\AbstractPart $part Type hint */
+                /** @var \Shareforce\PhpWord\Writer\RTF\Part\AbstractPart $part Type hint */
                 $part = new $partClass();
                 $part->setParentWriter($this);
                 $this->writerParts[strtolower($partName)] = $part;
@@ -58,7 +58,7 @@ class RTF extends AbstractWriter implements WriterInterface
      * Save content to file.
      *
      * @param string $filename
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      */
     public function save($filename = null)
     {

--- a/src/PhpWord/Writer/RTF/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/RTF/Element/AbstractElement.php
@@ -15,19 +15,19 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
-use PhpOffice\PhpWord\Element\AbstractElement as Element;
-use PhpOffice\PhpWord\Escaper\Rtf;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\Text as SharedText;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Font as FontStyle;
-use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
-use PhpOffice\PhpWord\Writer\AbstractWriter;
-use PhpOffice\PhpWord\Writer\HTML\Element\AbstractElement as HTMLAbstractElement;
-use PhpOffice\PhpWord\Writer\RTF\Style\Font as FontStyleWriter;
-use PhpOffice\PhpWord\Writer\RTF\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Element\AbstractElement as Element;
+use Shareforce\PhpWord\Escaper\Rtf;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Font as FontStyle;
+use Shareforce\PhpWord\Style\Paragraph as ParagraphStyle;
+use Shareforce\PhpWord\Writer\AbstractWriter;
+use Shareforce\PhpWord\Writer\HTML\Element\AbstractElement as HTMLAbstractElement;
+use Shareforce\PhpWord\Writer\RTF\Style\Font as FontStyleWriter;
+use Shareforce\PhpWord\Writer\RTF\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * Abstract RTF element writer
@@ -39,14 +39,14 @@ abstract class AbstractElement extends HTMLAbstractElement
     /**
      * Font style
      *
-     * @var \PhpOffice\PhpWord\Style\Font
+     * @var \Shareforce\PhpWord\Style\Font
      */
     protected $fontStyle;
 
     /**
      * Paragraph style
      *
-     * @var \PhpOffice\PhpWord\Style\Paragraph
+     * @var \Shareforce\PhpWord\Style\Paragraph
      */
     protected $paragraphStyle;
 
@@ -62,10 +62,10 @@ abstract class AbstractElement extends HTMLAbstractElement
      */
     protected function getStyles()
     {
-        /** @var \PhpOffice\PhpWord\Writer\RTF $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\RTF $parentWriter Type hint */
         $parentWriter = $this->parentWriter;
 
-        /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
 
         // Font style
@@ -154,7 +154,7 @@ abstract class AbstractElement extends HTMLAbstractElement
             return '';
         }
 
-        /** @var \PhpOffice\PhpWord\Writer\RTF $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\RTF $parentWriter Type hint */
         $parentWriter = $this->parentWriter;
 
         // Create style writer and set color/name index

--- a/src/PhpWord/Writer/RTF/Element/Container.php
+++ b/src/PhpWord/Writer/RTF/Element/Container.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
-use PhpOffice\PhpWord\Writer\HTML\Element\Container as HTMLContainer;
+use Shareforce\PhpWord\Writer\HTML\Element\Container as HTMLContainer;
 
 /**
  * Container element RTF writer
@@ -31,5 +31,5 @@ class Container extends HTMLContainer
      *
      * @var string
      */
-    protected $namespace = 'PhpOffice\\PhpWord\\Writer\\RTF\\Element';
+    protected $namespace = 'Shareforce\\PhpWord\\Writer\\RTF\\Element';
 }

--- a/src/PhpWord/Writer/RTF/Element/Field.php
+++ b/src/PhpWord/Writer/RTF/Element/Field.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * Field element writer
@@ -30,7 +30,7 @@ class Field extends Text
     public function write()
     {
         $element = $this->element;
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Field) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Field) {
             return;
         }
 
@@ -66,7 +66,7 @@ class Field extends Text
         return 'NUMPAGES';
     }
 
-    protected function writeDate(\PhpOffice\PhpWord\Element\Field $element)
+    protected function writeDate(\Shareforce\PhpWord\Element\Field $element)
     {
         $content = '';
         $content .= 'DATE';

--- a/src/PhpWord/Writer/RTF/Element/Image.php
+++ b/src/PhpWord/Writer/RTF/Element/Image.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
-use PhpOffice\PhpWord\Element\Image as ImageElement;
-use PhpOffice\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Element\Image as ImageElement;
+use Shareforce\PhpWord\Shared\Converter;
 
 /**
  * Image element RTF writer

--- a/src/PhpWord/Writer/RTF/Element/Link.php
+++ b/src/PhpWord/Writer/RTF/Element/Link.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * Link element RTF writer
@@ -31,7 +31,7 @@ class Link extends AbstractElement
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\Link) {
+        if (!$this->element instanceof \Shareforce\PhpWord\Element\Link) {
             return '';
         }
 

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * ListItem element RTF writer; extends from text

--- a/src/PhpWord/Writer/RTF/Element/PageBreak.php
+++ b/src/PhpWord/Writer/RTF/Element/PageBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * PageBreak element RTF writer

--- a/src/PhpWord/Writer/RTF/Element/Table.php
+++ b/src/PhpWord/Writer/RTF/Element/Table.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
-use PhpOffice\PhpWord\Element\Cell as CellElement;
-use PhpOffice\PhpWord\Element\Row as RowElement;
-use PhpOffice\PhpWord\Element\Table as TableElement;
+use Shareforce\PhpWord\Element\Cell as CellElement;
+use Shareforce\PhpWord\Element\Row as RowElement;
+use Shareforce\PhpWord\Element\Table as TableElement;
 
 /**
  * Table element RTF writer
@@ -67,7 +67,7 @@ class Table extends AbstractElement
     /**
      * Write column
      *
-     * @param \PhpOffice\PhpWord\Element\Row $row
+     * @param \Shareforce\PhpWord\Element\Row $row
      * @return string
      */
     private function writeRowDef(RowElement $row)
@@ -91,7 +91,7 @@ class Table extends AbstractElement
     /**
      * Write row
      *
-     * @param \PhpOffice\PhpWord\Element\Row $row
+     * @param \Shareforce\PhpWord\Element\Row $row
      * @return string
      */
     private function writeRow(RowElement $row)
@@ -109,7 +109,7 @@ class Table extends AbstractElement
     /**
      * Write cell
      *
-     * @param \PhpOffice\PhpWord\Element\Cell $cell
+     * @param \Shareforce\PhpWord\Element\Cell $cell
      * @return string
      */
     private function writeCell(CellElement $cell)

--- a/src/PhpWord/Writer/RTF/Element/Text.php
+++ b/src/PhpWord/Writer/RTF/Element/Text.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * Text element RTF writer
@@ -31,7 +31,7 @@ class Text extends AbstractElement
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
         $elementClass = str_replace('\\Writer\\RTF', '', get_class($this));
         if (!$element instanceof $elementClass || !is_string($element->getText())) {

--- a/src/PhpWord/Writer/RTF/Element/TextBreak.php
+++ b/src/PhpWord/Writer/RTF/Element/TextBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * TextBreak element RTF writer
@@ -31,7 +31,7 @@ class TextBreak extends AbstractElement
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Writer\RTF $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\RTF $parentWriter Type hint */
         $parentWriter = $this->parentWriter;
         $parentWriter->setLastParagraphStyle();
 

--- a/src/PhpWord/Writer/RTF/Element/TextRun.php
+++ b/src/PhpWord/Writer/RTF/Element/TextRun.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * TextRun element RTF writer

--- a/src/PhpWord/Writer/RTF/Element/Title.php
+++ b/src/PhpWord/Writer/RTF/Element/Title.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Element;
+namespace Shareforce\PhpWord\Writer\RTF\Element;
 
 /**
  * Title element RTF writer; extends from text
@@ -26,17 +26,17 @@ class Title extends Text
 {
     protected function getStyles()
     {
-        /** @var \PhpOffice\PhpWord\Element\Title $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\Title $element Type hint */
         $element = $this->element;
         $style = $element->getStyle();
         $style = str_replace('Heading', 'Heading_', $style);
-        $style = \PhpOffice\PhpWord\Style::getStyle($style);
-        if ($style instanceof \PhpOffice\PhpWord\Style\Font) {
+        $style = \Shareforce\PhpWord\Style::getStyle($style);
+        if ($style instanceof \Shareforce\PhpWord\Style\Font) {
             $this->fontStyle = $style;
             $pstyle = $style->getParagraph();
-            if ($pstyle instanceof \PhpOffice\PhpWord\Style\Paragraph && $pstyle->hasPageBreakBefore()) {
+            if ($pstyle instanceof \Shareforce\PhpWord\Style\Paragraph && $pstyle->hasPageBreakBefore()) {
                 $sect = $element->getParent();
-                if ($sect instanceof \PhpOffice\PhpWord\Element\Section) {
+                if ($sect instanceof \Shareforce\PhpWord\Element\Section) {
                     $elems = $sect->getElements();
                     if ($elems[0] === $element) {
                         $pstyle = clone $pstyle;
@@ -55,7 +55,7 @@ class Title extends Text
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Element\Title $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\Title $element Type hint */
         $element = $this->element;
         $elementClass = str_replace('\\Writer\\RTF', '', get_class($this));
         if (!$element instanceof $elementClass || !is_string($element->getText())) {

--- a/src/PhpWord/Writer/RTF/Part/AbstractPart.php
+++ b/src/PhpWord/Writer/RTF/Part/AbstractPart.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Part;
+namespace Shareforce\PhpWord\Writer\RTF\Part;
 
-use PhpOffice\PhpWord\Escaper\Rtf;
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\Writer\AbstractWriter;
+use Shareforce\PhpWord\Escaper\Rtf;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Writer\AbstractWriter;
 
 /**
  * @since 0.11.0
@@ -27,12 +27,12 @@ use PhpOffice\PhpWord\Writer\AbstractWriter;
 abstract class AbstractPart
 {
     /**
-     * @var \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @var \Shareforce\PhpWord\Writer\AbstractWriter
      */
     private $parentWriter;
 
     /**
-     * @var \PhpOffice\PhpWord\Escaper\EscaperInterface
+     * @var \Shareforce\PhpWord\Escaper\EscaperInterface
      */
     protected $escaper;
 
@@ -47,7 +47,7 @@ abstract class AbstractPart
     abstract public function write();
 
     /**
-     * @param \PhpOffice\PhpWord\Writer\AbstractWriter $writer
+     * @param \Shareforce\PhpWord\Writer\AbstractWriter $writer
      */
     public function setParentWriter(AbstractWriter $writer = null)
     {
@@ -55,8 +55,8 @@ abstract class AbstractPart
     }
 
     /**
-     * @throws \PhpOffice\PhpWord\Exception\Exception
-     * @return \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @throws \Shareforce\PhpWord\Exception\Exception
+     * @return \Shareforce\PhpWord\Writer\AbstractWriter
      */
     public function getParentWriter()
     {

--- a/src/PhpWord/Writer/RTF/Part/Document.php
+++ b/src/PhpWord/Writer/RTF/Part/Document.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Part;
+namespace Shareforce\PhpWord\Writer\RTF\Part;
 
-use PhpOffice\PhpWord\Element\Footer;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Writer\RTF\Element\Container;
-use PhpOffice\PhpWord\Writer\RTF\Style\Section as SectionStyleWriter;
+use Shareforce\PhpWord\Element\Footer;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Writer\RTF\Element\Container;
+use Shareforce\PhpWord\Writer\RTF\Style\Section as SectionStyleWriter;
 
 /**
  * RTF document part writer
@@ -117,7 +117,7 @@ class Document extends AbstractPart
     /**
      * Write titlepg directive if any "f" headers or footers
      *
-     * @param \PhpOffice\PhpWord\Element\Section $section
+     * @param \Shareforce\PhpWord\Element\Section $section
      * @return string
      */
     private static function writeTitlepg($section)

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Part;
+namespace Shareforce\PhpWord\Writer\RTF\Part;
 
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\Converter;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Font;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Font;
 
 /**
  * RTF header part writer
@@ -210,7 +210,7 @@ class Header extends AbstractPart
     /**
      * Register border colors.
      *
-     * @param \PhpOffice\PhpWord\Style\Border $style
+     * @param \Shareforce\PhpWord\Style\Border $style
      */
     private function registerBorderColor($style)
     {
@@ -225,7 +225,7 @@ class Header extends AbstractPart
     /**
      * Register fonts and colors.
      *
-     * @param \PhpOffice\PhpWord\Style\AbstractStyle $style
+     * @param \Shareforce\PhpWord\Style\AbstractStyle $style
      */
     private function registerFontItems($style)
     {

--- a/src/PhpWord/Writer/RTF/Style/AbstractStyle.php
+++ b/src/PhpWord/Writer/RTF/Style/AbstractStyle.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Style;
+namespace Shareforce\PhpWord\Writer\RTF\Style;
 
-use PhpOffice\PhpWord\Writer\HTML\Style\AbstractStyle as HTMLAbstractStyle;
+use Shareforce\PhpWord\Writer\HTML\Style\AbstractStyle as HTMLAbstractStyle;
 
 /**
  * Abstract RTF style writer

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Style;
+namespace Shareforce\PhpWord\Writer\RTF\Style;
 
 /**
  * Border style writer
@@ -77,7 +77,7 @@ class Border extends AbstractStyle
      */
     private function writeSide($side, $width, $color = '')
     {
-        /** @var \PhpOffice\PhpWord\Writer\RTF $rtfWriter */
+        /** @var \Shareforce\PhpWord\Writer\RTF $rtfWriter */
         $rtfWriter = $this->getParentWriter();
         $colorIndex = 0;
         if ($rtfWriter !== null) {

--- a/src/PhpWord/Writer/RTF/Style/Font.php
+++ b/src/PhpWord/Writer/RTF/Style/Font.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Style;
+namespace Shareforce\PhpWord\Writer\RTF\Style;
 
-use PhpOffice\PhpWord\Style\Font as FontStyle;
+use Shareforce\PhpWord\Style\Font as FontStyle;
 
 /**
  * RTF font style writer

--- a/src/PhpWord/Writer/RTF/Style/Indentation.php
+++ b/src/PhpWord/Writer/RTF/Style/Indentation.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Style;
+namespace Shareforce\PhpWord\Writer\RTF\Style;
 
 /**
  * RTF indentation style writer
@@ -32,7 +32,7 @@ class Indentation extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Indentation) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Indentation) {
             return '';
         }
 

--- a/src/PhpWord/Writer/RTF/Style/Paragraph.php
+++ b/src/PhpWord/Writer/RTF/Style/Paragraph.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Style;
+namespace Shareforce\PhpWord\Writer\RTF\Style;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
  * RTF paragraph style writer
@@ -43,7 +43,7 @@ class Paragraph extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Paragraph) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Paragraph) {
             return '';
         }
 
@@ -83,14 +83,14 @@ class Paragraph extends AbstractStyle
     }
 
     /**
-     * Writes an \PhpOffice\PhpWord\Style\Indentation
+     * Writes an \Shareforce\PhpWord\Style\Indentation
      *
-     * @param null|\PhpOffice\PhpWord\Style\Indentation $indent
+     * @param null|\Shareforce\PhpWord\Style\Indentation $indent
      * @return string
      */
     private function writeIndentation($indent = null)
     {
-        if (isset($indent) && $indent instanceof \PhpOffice\PhpWord\Style\Indentation) {
+        if (isset($indent) && $indent instanceof \Shareforce\PhpWord\Style\Indentation) {
             $writer = new Indentation($indent);
 
             return $writer->write();
@@ -102,7 +102,7 @@ class Paragraph extends AbstractStyle
     /**
      * Writes tabs
      *
-     * @param \PhpOffice\PhpWord\Style\Tab[] $tabs
+     * @param \Shareforce\PhpWord\Style\Tab[] $tabs
      * @return string
      */
     private function writeTabs($tabs = null)

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Style;
+namespace Shareforce\PhpWord\Writer\RTF\Style;
 
-use PhpOffice\PhpWord\Style\Section as SectionStyle;
+use Shareforce\PhpWord\Style\Section as SectionStyle;
 
 /**
  * RTF section style writer

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF\Style;
+namespace Shareforce\PhpWord\Writer\RTF\Style;
 
 /**
  * Line numbering style writer
@@ -30,13 +30,13 @@ class Tab extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Tab) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Tab) {
             return;
         }
         $tabs = array(
-            \PhpOffice\PhpWord\Style\Tab::TAB_STOP_RIGHT   => '\tqr',
-            \PhpOffice\PhpWord\Style\Tab::TAB_STOP_CENTER  => '\tqc',
-            \PhpOffice\PhpWord\Style\Tab::TAB_STOP_DECIMAL => '\tqdec',
+            \Shareforce\PhpWord\Style\Tab::TAB_STOP_RIGHT   => '\tqr',
+            \Shareforce\PhpWord\Style\Tab::TAB_STOP_CENTER  => '\tqc',
+            \Shareforce\PhpWord\Style\Tab::TAB_STOP_DECIMAL => '\tqdec',
         );
         $content = '';
         if (isset($tabs[$style->getType()])) {

--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\Media;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\ZipArchive;
+use Shareforce\PhpWord\Element\Section;
+use Shareforce\PhpWord\Media;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\ZipArchive;
 
 /**
  * Word2007 writer
@@ -44,7 +44,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
     /**
      * Create new Word2007 writer
      *
-     * @param \PhpOffice\PhpWord\PhpWord
+     * @param \Shareforce\PhpWord\PhpWord
      */
     public function __construct(PhpWord $phpWord = null)
     {
@@ -77,7 +77,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
         foreach (array_keys($this->parts) as $partName) {
             $partClass = get_class($this) . '\\Part\\' . $partName;
             if (class_exists($partClass)) {
-                /** @var \PhpOffice\PhpWord\Writer\Word2007\Part\AbstractPart $part Type hint */
+                /** @var \Shareforce\PhpWord\Writer\Word2007\Part\AbstractPart $part Type hint */
                 $part = new $partClass();
                 $part->setParentWriter($this);
                 $this->writerParts[strtolower($partName)] = $part;
@@ -167,7 +167,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
     /**
      * Add header/footer media files, e.g. footer1.xml.rels.
      *
-     * @param \PhpOffice\PhpWord\Shared\ZipArchive $zip
+     * @param \Shareforce\PhpWord\Shared\ZipArchive $zip
      * @param string $docPart
      */
     private function addHeaderFooterMedia(ZipArchive $zip, $docPart)
@@ -181,7 +181,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
                         $this->registerContentTypes($media);
                     }
 
-                    /** @var \PhpOffice\PhpWord\Writer\Word2007\Part\AbstractPart $writerPart Type hint */
+                    /** @var \Shareforce\PhpWord\Writer\Word2007\Part\AbstractPart $writerPart Type hint */
                     $writerPart = $this->getWriterPart('relspart')->setMedia($media);
                     $zip->addFromString("word/_rels/{$file}.xml.rels", $writerPart->write());
                 }
@@ -192,8 +192,8 @@ class Word2007 extends AbstractWriter implements WriterInterface
     /**
      * Add header/footer content.
      *
-     * @param \PhpOffice\PhpWord\Element\Section &$section
-     * @param \PhpOffice\PhpWord\Shared\ZipArchive $zip
+     * @param \Shareforce\PhpWord\Element\Section &$section
+     * @param \Shareforce\PhpWord\Shared\ZipArchive $zip
      * @param string $elmType header|footer
      * @param int &$rId
      */
@@ -202,7 +202,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
         $getFunction = $elmType == 'header' ? 'getHeaders' : 'getFooters';
         $elmCount = ($section->getSectionId() - 1) * 3;
         $elements = $section->$getFunction();
-        /** @var \PhpOffice\PhpWord\Element\AbstractElement $element Type hint */
+        /** @var \Shareforce\PhpWord\Element\AbstractElement $element Type hint */
         foreach ($elements as &$element) {
             $elmCount++;
             $element->setRelationId(++$rId);
@@ -210,7 +210,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
             $this->contentTypes['override']["/word/$elmFile"] = $elmType;
             $this->relationships[] = array('target' => $elmFile, 'type' => $elmType, 'rID' => $rId);
 
-            /** @var \PhpOffice\PhpWord\Writer\Word2007\Part\AbstractPart $writerPart Type hint */
+            /** @var \Shareforce\PhpWord\Writer\Word2007\Part\AbstractPart $writerPart Type hint */
             $writerPart = $this->getWriterPart($elmType)->setElement($element);
             $zip->addFromString("word/$elmFile", $writerPart->write());
         }
@@ -219,7 +219,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
     /**
      * Add footnotes/endnotes
      *
-     * @param \PhpOffice\PhpWord\Shared\ZipArchive $zip
+     * @param \Shareforce\PhpWord\Shared\ZipArchive $zip
      * @param int &$rId
      * @param string $noteType
      */
@@ -232,7 +232,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
         $collection = $phpWord->$method();
 
         // Add footnotes media files, relations, and contents
-        /** @var \PhpOffice\PhpWord\Collection\AbstractCollection $collection Type hint */
+        /** @var \Shareforce\PhpWord\Collection\AbstractCollection $collection Type hint */
         if ($collection->countItems() > 0) {
             $media = Media::getElements($noteType);
             $this->addFilesToPackage($zip, $media);
@@ -242,7 +242,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
 
             // Write relationships file, e.g. word/_rels/footnotes.xml
             if (!empty($media)) {
-                /** @var \PhpOffice\PhpWord\Writer\Word2007\Part\AbstractPart $writerPart Type hint */
+                /** @var \Shareforce\PhpWord\Writer\Word2007\Part\AbstractPart $writerPart Type hint */
                 $writerPart = $this->getWriterPart('relspart')->setMedia($media);
                 $zip->addFromString("word/_rels/{$partName}.xml.rels", $writerPart->write());
             }
@@ -256,7 +256,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
     /**
      * Add comments
      *
-     * @param \PhpOffice\PhpWord\Shared\ZipArchive $zip
+     * @param \Shareforce\PhpWord\Shared\ZipArchive $zip
      * @param int &$rId
      */
     private function addComments(ZipArchive $zip, &$rId)
@@ -266,7 +266,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
         $partName = 'comments';
 
         // Add comment relations and contents
-        /** @var \PhpOffice\PhpWord\Collection\AbstractCollection $collection Type hint */
+        /** @var \Shareforce\PhpWord\Collection\AbstractCollection $collection Type hint */
         if ($collection->countItems() > 0) {
             $this->relationships[] = array('target' => "{$partName}.xml", 'type' => $partName, 'rID' => ++$rId);
 
@@ -279,7 +279,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
     /**
      * Add chart.
      *
-     * @param \PhpOffice\PhpWord\Shared\ZipArchive $zip
+     * @param \Shareforce\PhpWord\Shared\ZipArchive $zip
      * @param int &$rId
      */
     private function addChart(ZipArchive $zip, &$rId)
@@ -289,7 +289,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
         $collection = $phpWord->getCharts();
         $index = 0;
         if ($collection->countItems() > 0) {
-            /** @var \PhpOffice\PhpWord\Element\Chart $chart */
+            /** @var \Shareforce\PhpWord\Element\Chart $chart */
             foreach ($collection->getItems() as $chart) {
                 $index++;
                 $rId++;

--- a/src/PhpWord/Writer/Word2007/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/Word2007/Element/AbstractElement.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\AbstractElement as Element;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\Text as SharedText;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Element\AbstractElement as Element;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\Text as SharedText;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Abstract element writer
@@ -32,14 +32,14 @@ abstract class AbstractElement
     /**
      * XML writer
      *
-     * @var \PhpOffice\PhpWord\Shared\XMLWriter
+     * @var \Shareforce\PhpWord\Shared\XMLWriter
      */
     private $xmlWriter;
 
     /**
      * Element
      *
-     * @var \PhpOffice\PhpWord\Element\AbstractElement
+     * @var \Shareforce\PhpWord\Element\AbstractElement
      */
     private $element;
 
@@ -58,8 +58,8 @@ abstract class AbstractElement
     /**
      * Create new instance
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\AbstractElement $element
      * @param bool $withoutP
      */
     public function __construct(XMLWriter $xmlWriter, Element $element, $withoutP = false)
@@ -72,7 +72,7 @@ abstract class AbstractElement
     /**
      * Get XML Writer
      *
-     * @return \PhpOffice\PhpWord\Shared\XMLWriter
+     * @return \Shareforce\PhpWord\Shared\XMLWriter
      */
     protected function getXmlWriter()
     {
@@ -82,7 +82,7 @@ abstract class AbstractElement
     /**
      * Get element
      *
-     * @return \PhpOffice\PhpWord\Element\AbstractElement
+     * @return \Shareforce\PhpWord\Element\AbstractElement
      */
     protected function getElement()
     {
@@ -92,7 +92,7 @@ abstract class AbstractElement
     /**
      * Start w:p DOM element.
      *
-     * @uses \PhpOffice\PhpWord\Writer\Word2007\Element\PageBreak::write()
+     * @uses \Shareforce\PhpWord\Writer\Word2007\Element\PageBreak::write()
      */
     protected function startElementP()
     {
@@ -187,10 +187,10 @@ abstract class AbstractElement
     private function writeTextStyle($styleType)
     {
         $method = "get{$styleType}Style";
-        $class = "PhpOffice\\PhpWord\\Writer\\Word2007\\Style\\{$styleType}";
+        $class = "Shareforce\\PhpWord\\Writer\\Word2007\\Style\\{$styleType}";
         $styleObject = $this->element->$method();
 
-        /** @var \PhpOffice\PhpWord\Writer\Word2007\Style\AbstractStyle $styleWriter Type Hint */
+        /** @var \Shareforce\PhpWord\Writer\Word2007\Style\AbstractStyle $styleWriter Type Hint */
         $styleWriter = new $class($this->xmlWriter, $styleObject);
         if (method_exists($styleWriter, 'setIsInline')) {
             $styleWriter->setIsInline(true);

--- a/src/PhpWord/Writer/Word2007/Element/Bookmark.php
+++ b/src/PhpWord/Writer/Word2007/Element/Bookmark.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * Bookmark element writer
@@ -31,7 +31,7 @@ class Bookmark extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Bookmark) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Bookmark) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Element/Chart.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\Chart as ChartElement;
+use Shareforce\PhpWord\Element\Chart as ChartElement;
 
 /**
  * Chart element writer

--- a/src/PhpWord/Writer/Word2007/Element/CheckBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/CheckBox.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * CheckBox element writer
@@ -31,7 +31,7 @@ class CheckBox extends Text
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\CheckBox) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\CheckBox) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/Container.php
+++ b/src/PhpWord/Writer/Word2007/Element/Container.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\AbstractContainer as ContainerElement;
-use PhpOffice\PhpWord\Element\AbstractElement as Element;
-use PhpOffice\PhpWord\Element\TextBreak as TextBreakElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Element\AbstractContainer as ContainerElement;
+use Shareforce\PhpWord\Element\AbstractElement as Element;
+use Shareforce\PhpWord\Element\TextBreak as TextBreakElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Container element writer (section, textrun, header, footnote, cell, etc.)
@@ -34,7 +34,7 @@ class Container extends AbstractElement
      *
      * @var string
      */
-    protected $namespace = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element';
+    protected $namespace = 'Shareforce\\PhpWord\\Writer\\Word2007\\Element';
 
     /**
      * Write element.
@@ -62,7 +62,7 @@ class Container extends AbstractElement
         $writeLastTextBreak = ($containerClass == 'Cell') && ($elementClass == '' || $elementClass == 'Table');
         if ($writeLastTextBreak) {
             $writerClass = $this->namespace . '\\TextBreak';
-            /** @var \PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement $writer Type hint */
+            /** @var \Shareforce\PhpWord\Writer\Word2007\Element\AbstractElement $writer Type hint */
             $writer = new $writerClass($xmlWriter, new TextBreakElement(), $withoutP);
             $writer->write();
         }
@@ -71,8 +71,8 @@ class Container extends AbstractElement
     /**
      * Write individual element
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\AbstractElement $element
      * @param bool $withoutP
      * @return string
      */
@@ -82,7 +82,7 @@ class Container extends AbstractElement
         $writerClass = $this->namespace . '\\' . $elementClass;
 
         if (class_exists($writerClass)) {
-            /** @var \PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement $writer Type hint */
+            /** @var \Shareforce\PhpWord\Writer\Word2007\Element\AbstractElement $writer Type hint */
             $writer = new $writerClass($xmlWriter, $element, $withoutP);
             $writer->write();
         }

--- a/src/PhpWord/Writer/Word2007/Element/Endnote.php
+++ b/src/PhpWord/Writer/Word2007/Element/Endnote.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * Endnote element writer

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -212,4 +212,98 @@ class Field extends Text
 
         return $propertiesAndOptions;
     }
+
+    /**
+     * Writes a REF field
+     *
+     * @param \PhpOffice\PhpWord\Element\Field $element
+     */
+    protected function writeRef(\PhpOffice\PhpWord\Element\Field $element)
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $this->startElementP();
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'begin');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
+        $instruction = ' ' . $element->getType() . ' ';
+
+        foreach ($element->getProperties() as $property) {
+            $instruction .= $property . ' ';
+        }
+        foreach ($element->getOptions() as $optionKey => $optionValue) {
+            $instruction .= $this->convertRefOption($optionKey, $optionValue) . ' ';
+        }
+
+        $xmlWriter->startElement('w:r');
+        $this->writeFontStyle();
+        $xmlWriter->startElement('w:instrText');
+        $xmlWriter->writeAttribute('xml:space', 'preserve');
+        $xmlWriter->text($instruction);
+        $xmlWriter->endElement(); // w:instrText
+        $xmlWriter->endElement(); // w:r
+
+        if ($element->getText() != null) {
+            if ($element->getText() instanceof \PhpOffice\PhpWord\Element\TextRun) {
+                $containerWriter = new Container($xmlWriter, $element->getText(), true);
+                $containerWriter->write();
+
+                $xmlWriter->startElement('w:r');
+                $xmlWriter->startElement('w:instrText');
+                $xmlWriter->text('"' . $this->buildPropertiesAndOptions($element));
+                $xmlWriter->endElement(); // w:instrText
+                $xmlWriter->endElement(); // w:r
+
+                $xmlWriter->startElement('w:r');
+                $xmlWriter->startElement('w:instrText');
+                $xmlWriter->writeAttribute('xml:space', 'preserve');
+                $xmlWriter->text(' ');
+                $xmlWriter->endElement(); // w:instrText
+                $xmlWriter->endElement(); // w:r
+            }
+        }
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'separate');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:rPr');
+        $xmlWriter->startElement('w:noProof');
+        $xmlWriter->endElement(); // w:noProof
+        $xmlWriter->endElement(); // w:rPr
+        $xmlWriter->writeElement('w:t', $element->getText() != null && is_string($element->getText()) ? $element->getText() : '1');
+        $xmlWriter->endElement(); // w:r
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'end');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
+        $this->endElementP(); // w:p
+    }
+
+    private function convertRefOption($optionKey, $optionValue)
+    {
+        if ($optionKey === 'NumberSeperatorSequence') {
+            return '\\d ' . $optionValue;
+        }
+
+        switch ($optionValue) {
+            case 'IncrementAndInsertText': return '\\f';
+            case 'CreateHyperLink': return '\\h';
+            case 'NoTrailingPeriod': return '\\n';
+            case 'IncludeAboveOrBelow': return '\\p';
+            case 'InsertParagraphNumberRelativeContext': return '\\r';
+            case 'SuppressNonDelimeterNonNumericalText': return '\\t';
+            case 'InsertParagraphNumberFullContext': return '\\w';
+            default: return '';
+        }
+    }
 }

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * Field element writer
@@ -30,7 +30,7 @@ class Field extends Text
     public function write()
     {
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Field) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Field) {
             return;
         }
 
@@ -42,7 +42,7 @@ class Field extends Text
         }
     }
 
-    private function writeDefault(\PhpOffice\PhpWord\Element\Field $element)
+    private function writeDefault(\Shareforce\PhpWord\Element\Field $element)
     {
         $xmlWriter = $this->getXmlWriter();
         $this->startElementP();
@@ -73,7 +73,7 @@ class Field extends Text
         $xmlWriter->endElement(); // w:r
 
         if ($element->getText() != null) {
-            if ($element->getText() instanceof \PhpOffice\PhpWord\Element\TextRun) {
+            if ($element->getText() instanceof \Shareforce\PhpWord\Element\TextRun) {
                 $containerWriter = new Container($xmlWriter, $element->getText(), true);
                 $containerWriter->write();
 
@@ -119,9 +119,9 @@ class Field extends Text
      * Writes a macrobutton field
      *
      * //TODO A lot of code duplication with general method, should maybe be refactored
-     * @param \PhpOffice\PhpWord\Element\Field $element
+     * @param \Shareforce\PhpWord\Element\Field $element
      */
-    protected function writeMacrobutton(\PhpOffice\PhpWord\Element\Field $element)
+    protected function writeMacrobutton(\Shareforce\PhpWord\Element\Field $element)
     {
         $xmlWriter = $this->getXmlWriter();
         $this->startElementP();
@@ -145,7 +145,7 @@ class Field extends Text
         $xmlWriter->endElement(); // w:r
 
         if ($element->getText() != null) {
-            if ($element->getText() instanceof \PhpOffice\PhpWord\Element\TextRun) {
+            if ($element->getText() instanceof \Shareforce\PhpWord\Element\TextRun) {
                 $containerWriter = new Container($xmlWriter, $element->getText(), true);
                 $containerWriter->write();
             }
@@ -160,7 +160,7 @@ class Field extends Text
         $this->endElementP(); // w:p
     }
 
-    private function buildPropertiesAndOptions(\PhpOffice\PhpWord\Element\Field $element)
+    private function buildPropertiesAndOptions(\Shareforce\PhpWord\Element\Field $element)
     {
         $propertiesAndOptions = '';
         $properties = $element->getProperties();
@@ -216,9 +216,9 @@ class Field extends Text
     /**
      * Writes a REF field
      *
-     * @param \PhpOffice\PhpWord\Element\Field $element
+     * @param \Shareforce\PhpWord\Element\Field $element
      */
-    protected function writeRef(\PhpOffice\PhpWord\Element\Field $element)
+    protected function writeRef(\Shareforce\PhpWord\Element\Field $element)
     {
         $xmlWriter = $this->getXmlWriter();
         $this->startElementP();
@@ -247,7 +247,7 @@ class Field extends Text
         $xmlWriter->endElement(); // w:r
 
         if ($element->getText() != null) {
-            if ($element->getText() instanceof \PhpOffice\PhpWord\Element\TextRun) {
+            if ($element->getText() instanceof \Shareforce\PhpWord\Element\TextRun) {
                 $containerWriter = new Container($xmlWriter, $element->getText(), true);
                 $containerWriter->write();
 

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -301,7 +301,7 @@ class Field extends Text
             case 'NoTrailingPeriod': return '\\n';
             case 'IncludeAboveOrBelow': return '\\p';
             case 'InsertParagraphNumberRelativeContext': return '\\r';
-            case 'SuppressNonDelimeterNonNumericalText': return '\\t';
+            case 'SuppressNonDelimiterNonNumericalText': return '\\t';
             case 'InsertParagraphNumberFullContext': return '\\w';
             default: return '';
         }

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -296,14 +296,22 @@ class Field extends Text
         }
 
         switch ($optionValue) {
-            case 'IncrementAndInsertText': return '\\f';
-            case 'CreateHyperLink': return '\\h';
-            case 'NoTrailingPeriod': return '\\n';
-            case 'IncludeAboveOrBelow': return '\\p';
-            case 'InsertParagraphNumberRelativeContext': return '\\r';
-            case 'SuppressNonDelimiterNonNumericalText': return '\\t';
-            case 'InsertParagraphNumberFullContext': return '\\w';
-            default: return '';
+            case 'IncrementAndInsertText':
+                return '\\f';
+            case 'CreateHyperLink':
+                return '\\h';
+            case 'NoTrailingPeriod':
+                return '\\n';
+            case 'IncludeAboveOrBelow':
+                return '\\p';
+            case 'InsertParagraphNumberRelativeContext':
+                return '\\r';
+            case 'SuppressNonDelimiterNonNumericalText':
+                return '\\t';
+            case 'InsertParagraphNumberFullContext':
+                return '\\w';
+            default:
+                return '';
         }
     }
 }

--- a/src/PhpWord/Writer/Word2007/Element/Footnote.php
+++ b/src/PhpWord/Writer/Word2007/Element/Footnote.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * Footnote element writer
@@ -38,7 +38,7 @@ class Footnote extends Text
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Footnote) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Footnote) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/FormField.php
+++ b/src/PhpWord/Writer/Word2007/Element/FormField.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\FormField as FormFieldElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Element\FormField as FormFieldElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * FormField element writer
@@ -105,8 +105,8 @@ class FormField extends Text
      * Write textinput.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_FFTextInput.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\FormField $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\FormField $element
      */
     private function writeTextInput(XMLWriter $xmlWriter, FormFieldElement $element)
     {
@@ -121,8 +121,8 @@ class FormField extends Text
      * Write checkbox.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_FFCheckBox.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\FormField $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\FormField $element
      */
     private function writeCheckBox(XMLWriter $xmlWriter, FormFieldElement $element)
     {
@@ -144,8 +144,8 @@ class FormField extends Text
      * Write dropdown.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_FFDDList.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\FormField $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\FormField $element
      */
     private function writeDropDown(XMLWriter $xmlWriter, FormFieldElement $element)
     {

--- a/src/PhpWord/Writer/Word2007/Element/Image.php
+++ b/src/PhpWord/Writer/Word2007/Element/Image.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\Image as ImageElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style\Font as FontStyle;
-use PhpOffice\PhpWord\Style\Frame as FrameStyle;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Font as FontStyleWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Image as ImageStyleWriter;
+use Shareforce\PhpWord\Element\Image as ImageElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style\Font as FontStyle;
+use Shareforce\PhpWord\Style\Frame as FrameStyle;
+use Shareforce\PhpWord\Writer\Word2007\Style\Font as FontStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Image as ImageStyleWriter;
 
 /**
  * Image element writer

--- a/src/PhpWord/Writer/Word2007/Element/Line.php
+++ b/src/PhpWord/Writer/Word2007/Element/Line.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\Line as LineElement;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Line as LineStyleWriter;
+use Shareforce\PhpWord\Element\Line as LineElement;
+use Shareforce\PhpWord\Writer\Word2007\Style\Line as LineStyleWriter;
 
 /**
  * Line element writer

--- a/src/PhpWord/Writer/Word2007/Element/Link.php
+++ b/src/PhpWord/Writer/Word2007/Element/Link.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * Link element writer
@@ -31,7 +31,7 @@ class Link extends Text
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Link) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Link) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/ListItem.php
+++ b/src/PhpWord/Writer/Word2007/Element/ListItem.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * ListItem element writer
@@ -33,7 +33,7 @@ class ListItem extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\ListItem) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\ListItem) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/ListItemRun.php
+++ b/src/PhpWord/Writer/Word2007/Element/ListItemRun.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\ListItemRun as ListItemRunElement;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Element\ListItemRun as ListItemRunElement;
+use Shareforce\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * ListItemRun element writer

--- a/src/PhpWord/Writer/Word2007/Element/OLEObject.php
+++ b/src/PhpWord/Writer/Word2007/Element/OLEObject.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Writer\Word2007\Style\Image as ImageStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Image as ImageStyleWriter;
 
 /**
  * OLEObject element writer
@@ -33,7 +33,7 @@ class OLEObject extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\OLEObject) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\OLEObject) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/PageBreak.php
+++ b/src/PhpWord/Writer/Word2007/Element/PageBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * PageBreak element writer
@@ -27,7 +27,7 @@ class PageBreak extends AbstractElement
     /**
      * Write element.
      *
-     * @usedby \PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement::startElementP()
+     * @usedby \Shareforce\PhpWord\Writer\Word2007\Element\AbstractElement::startElementP()
      */
     public function write()
     {

--- a/src/PhpWord/Writer/Word2007/Element/ParagraphAlignment.php
+++ b/src/PhpWord/Writer/Word2007/Element/ParagraphAlignment.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * @since 0.13.0
@@ -31,7 +31,7 @@ class ParagraphAlignment
      *
      * @param string $value Any value provided by Jc simple type
      *
-     * @see \PhpOffice\PhpWord\SimpleType\Jc For the allowed values of $value parameter.
+     * @see \Shareforce\PhpWord\SimpleType\Jc For the allowed values of $value parameter.
      */
     final public function __construct($value)
     {

--- a/src/PhpWord/Writer/Word2007/Element/PreserveText.php
+++ b/src/PhpWord/Writer/Word2007/Element/PreserveText.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * PreserveText element writer
@@ -31,7 +31,7 @@ class PreserveText extends Text
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\PreserveText) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\PreserveText) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/SDT.php
+++ b/src/PhpWord/Writer/Word2007/Element/SDT.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\SDT as SDTElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Element\SDT as SDTElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Structured document tag element writer
@@ -77,7 +77,7 @@ class SDT extends Text
      * Write text.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_SdtText.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writePlainText(XMLWriter $xmlWriter)
     {
@@ -89,8 +89,8 @@ class SDT extends Text
      * Write combo box.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_SdtComboBox.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\SDT $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\SDT $element
      */
     private function writeComboBox(XMLWriter $xmlWriter, SDTElement $element)
     {
@@ -108,8 +108,8 @@ class SDT extends Text
      * Write drop down list.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_SdtDropDownList.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\SDT $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\SDT $element
      */
     private function writeDropDownList(XMLWriter $xmlWriter, SDTElement $element)
     {
@@ -120,8 +120,8 @@ class SDT extends Text
      * Write date.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_SdtDate.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\SDT $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\SDT $element
      */
     private function writeDate(XMLWriter $xmlWriter, SDTElement $element)
     {

--- a/src/PhpWord/Writer/Word2007/Element/Shape.php
+++ b/src/PhpWord/Writer/Word2007/Element/Shape.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\Shape as ShapeElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style\Shape as ShapeStyle;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Shape as ShapeStyleWriter;
+use Shareforce\PhpWord\Element\Shape as ShapeElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style\Shape as ShapeStyle;
+use Shareforce\PhpWord\Writer\Word2007\Style\Shape as ShapeStyleWriter;
 
 /**
  * Shape element writer
@@ -77,8 +77,8 @@ class Shape extends AbstractElement
     /**
      * Write arc.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Shape $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Shape $style
      */
     private function writeArc(XMLWriter $xmlWriter, ShapeStyle $style)
     {
@@ -91,8 +91,8 @@ class Shape extends AbstractElement
     /**
      * Write curve.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Shape $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Shape $style
      */
     private function writeCurve(XMLWriter $xmlWriter, ShapeStyle $style)
     {
@@ -106,8 +106,8 @@ class Shape extends AbstractElement
     /**
      * Write line.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Shape $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Shape $style
      */
     private function writeLine(XMLWriter $xmlWriter, ShapeStyle $style)
     {
@@ -120,8 +120,8 @@ class Shape extends AbstractElement
     /**
      * Write polyline.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Shape $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Shape $style
      */
     private function writePolyline(XMLWriter $xmlWriter, ShapeStyle $style)
     {
@@ -131,8 +131,8 @@ class Shape extends AbstractElement
     /**
      * Write rectangle.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Shape $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Shape $style
      */
     private function writeRoundRect(XMLWriter $xmlWriter, ShapeStyle $style)
     {

--- a/src/PhpWord/Writer/Word2007/Element/TOC.php
+++ b/src/PhpWord/Writer/Word2007/Element/TOC.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\TOC as TOCElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Font as FontStyleWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Tab as TabStyleWriter;
+use Shareforce\PhpWord\Element\TOC as TOCElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Writer\Word2007\Style\Font as FontStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Tab as TabStyleWriter;
 
 /**
  * TOC element writer
@@ -64,9 +64,9 @@ class TOC extends AbstractElement
     /**
      * Write title
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\TOC $element
-     * @param \PhpOffice\PhpWord\Element\Title $title
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\TOC $element
+     * @param \Shareforce\PhpWord\Element\Title $title
      * @param bool $writeFieldMark
      */
     private function writeTitle(XMLWriter $xmlWriter, TOCElement $element, $title, $writeFieldMark)
@@ -132,8 +132,8 @@ class TOC extends AbstractElement
     /**
      * Write style
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\TOC $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\TOC $element
      * @param int $indent
      */
     private function writeStyle(XMLWriter $xmlWriter, TOCElement $element, $indent)
@@ -178,8 +178,8 @@ class TOC extends AbstractElement
     /**
      * Write TOC Field.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\TOC $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\TOC $element
      */
     private function writeFieldMark(XMLWriter $xmlWriter, TOCElement $element)
     {

--- a/src/PhpWord/Writer/Word2007/Element/Table.php
+++ b/src/PhpWord/Writer/Word2007/Element/Table.php
@@ -15,17 +15,17 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\Cell as CellElement;
-use PhpOffice\PhpWord\Element\Row as RowElement;
-use PhpOffice\PhpWord\Element\Table as TableElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style\Cell as CellStyle;
-use PhpOffice\PhpWord\Style\Row as RowStyle;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Cell as CellStyleWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Row as RowStyleWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Table as TableStyleWriter;
+use Shareforce\PhpWord\Element\Cell as CellElement;
+use Shareforce\PhpWord\Element\Row as RowElement;
+use Shareforce\PhpWord\Element\Table as TableElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style\Cell as CellStyle;
+use Shareforce\PhpWord\Style\Row as RowStyle;
+use Shareforce\PhpWord\Writer\Word2007\Style\Cell as CellStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Row as RowStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Table as TableStyleWriter;
 
 /**
  * Table element writer
@@ -71,8 +71,8 @@ class Table extends AbstractElement
     /**
      * Write column.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Table $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Table $element
      */
     private function writeColumns(XMLWriter $xmlWriter, TableElement $element)
     {
@@ -93,8 +93,8 @@ class Table extends AbstractElement
     /**
      * Write row.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Row $row
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Row $row
      */
     private function writeRow(XMLWriter $xmlWriter, RowElement $row)
     {
@@ -119,8 +119,8 @@ class Table extends AbstractElement
     /**
      * Write cell.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Cell $cell
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Cell $cell
      */
     private function writeCell(XMLWriter $xmlWriter, CellElement $cell)
     {

--- a/src/PhpWord/Writer/Word2007/Element/TableAlignment.php
+++ b/src/PhpWord/Writer/Word2007/Element/TableAlignment.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * @since 0.13.0
@@ -31,7 +31,7 @@ class TableAlignment
      *
      * @param string $value Any value provided by JcTable simple type
      *
-     * @see \PhpOffice\PhpWord\SimpleType\JcTable For the allowed values of $value parameter.
+     * @see \Shareforce\PhpWord\SimpleType\JcTable For the allowed values of $value parameter.
      */
     final public function __construct($value)
     {

--- a/src/PhpWord/Writer/Word2007/Element/Text.php
+++ b/src/PhpWord/Writer/Word2007/Element/Text.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\Element\TrackChange;
 
 /**
  * Text element writer
@@ -33,7 +33,7 @@ class Text extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Text) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Text) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBox.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Writer\Word2007\Style\TextBox as TextBoxStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\TextBox as TextBoxStyleWriter;
 
 /**
  * TextBox element writer
@@ -33,7 +33,7 @@ class TextBox extends Image
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\TextBox) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\TextBox) {
             return;
         }
         $style = $element->getStyle();

--- a/src/PhpWord/Writer/Word2007/Element/TextBreak.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBreak.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * TextBreak element writer
@@ -31,7 +31,7 @@ class TextBreak extends Text
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\TextBreak) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\TextBreak) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/TextRun.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextRun.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * TextRun element writer

--- a/src/PhpWord/Writer/Word2007/Element/Title.php
+++ b/src/PhpWord/Writer/Word2007/Element/Title.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
 /**
  * TextRun element writer
@@ -31,7 +31,7 @@ class Title extends AbstractElement
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\Title) {
+        if (!$element instanceof \Shareforce\PhpWord\Element\Title) {
             return;
         }
 
@@ -67,7 +67,7 @@ class Title extends AbstractElement
             $this->writeText($text);
             $xmlWriter->endElement(); // w:t
             $xmlWriter->endElement(); // w:r
-        } elseif ($text instanceof \PhpOffice\PhpWord\Element\AbstractContainer) {
+        } elseif ($text instanceof \Shareforce\PhpWord\Element\AbstractContainer) {
             $containerWriter = new Container($xmlWriter, $text);
             $containerWriter->write();
         }

--- a/src/PhpWord/Writer/Word2007/Part/AbstractPart.php
+++ b/src/PhpWord/Writer/Word2007/Part/AbstractPart.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Writer\AbstractWriter;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Writer\AbstractWriter;
 
 /**
  * Word2007 writer part abstract class
@@ -30,7 +30,7 @@ abstract class AbstractPart
     /**
      * Parent writer
      *
-     * @var \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @var \Shareforce\PhpWord\Writer\AbstractWriter
      */
     protected $parentWriter;
 
@@ -49,7 +49,7 @@ abstract class AbstractPart
     /**
      * Set parent writer.
      *
-     * @param \PhpOffice\PhpWord\Writer\AbstractWriter $writer
+     * @param \Shareforce\PhpWord\Writer\AbstractWriter $writer
      */
     public function setParentWriter(AbstractWriter $writer = null)
     {
@@ -59,8 +59,8 @@ abstract class AbstractPart
     /**
      * Get parent writer
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
-     * @return \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @throws \Shareforce\PhpWord\Exception\Exception
+     * @return \Shareforce\PhpWord\Writer\AbstractWriter
      */
     public function getParentWriter()
     {
@@ -73,7 +73,7 @@ abstract class AbstractPart
     /**
      * Get XML Writer
      *
-     * @return \PhpOffice\PhpWord\Shared\XMLWriter
+     * @return \Shareforce\PhpWord\Shared\XMLWriter
      */
     protected function getXmlWriter()
     {

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Element\Chart as ChartElement;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Element\Chart as ChartElement;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Word2007 chart part writer: word/charts/chartx.xml
@@ -31,7 +31,7 @@ class Chart extends AbstractPart
     /**
      * Chart element
      *
-     * @var \PhpOffice\PhpWord\Element\Chart
+     * @var \Shareforce\PhpWord\Element\Chart
      */
     private $element;
 
@@ -65,7 +65,7 @@ class Chart extends AbstractPart
     /**
      * Set chart element.
      *
-     * @param \PhpOffice\PhpWord\Element\Chart $element
+     * @param \Shareforce\PhpWord\Element\Chart $element
      */
     public function setElement(ChartElement $element)
     {
@@ -99,7 +99,7 @@ class Chart extends AbstractPart
      * Write chart
      *
      * @see  http://www.datypic.com/sc/ooxml/t-draw-chart_CT_Chart.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writeChart(XMLWriter $xmlWriter)
     {
@@ -121,7 +121,7 @@ class Chart extends AbstractPart
      * @see  http://www.datypic.com/sc/ooxml/t-draw-chart_CT_AreaChart.html
      * @see  http://www.datypic.com/sc/ooxml/t-draw-chart_CT_RadarChart.html
      * @see  http://www.datypic.com/sc/ooxml/t-draw-chart_CT_ScatterChart.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      */
     private function writePlotArea(XMLWriter $xmlWriter)
     {
@@ -213,7 +213,7 @@ class Chart extends AbstractPart
     /**
      * Write series.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param bool $scatter
      */
     private function writeSeries(XMLWriter $xmlWriter, $scatter = false)
@@ -297,7 +297,7 @@ class Chart extends AbstractPart
     /**
      * Write series items.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $type
      * @param array $values
      */
@@ -319,7 +319,7 @@ class Chart extends AbstractPart
         foreach ($values as $value) {
             $xmlWriter->startElement('c:pt');
             $xmlWriter->writeAttribute('idx', $index);
-            if (\PhpOffice\PhpWord\Settings::isOutputEscapingEnabled()) {
+            if (\Shareforce\PhpWord\Settings::isOutputEscapingEnabled()) {
                 $xmlWriter->writeElement('c:v', $value);
             } else {
                 $xmlWriter->startElement('c:v');
@@ -338,7 +338,7 @@ class Chart extends AbstractPart
      * Write axis
      *
      * @see  http://www.datypic.com/sc/ooxml/t-draw-chart_CT_CatAx.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $type
      */
     private function writeAxis(XMLWriter $xmlWriter, $type)
@@ -403,7 +403,7 @@ class Chart extends AbstractPart
      * Write shape
      *
      * @see  http://www.datypic.com/sc/ooxml/t-a_CT_ShapeProperties.html
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param bool $line
      */
     private function writeShape(XMLWriter $xmlWriter, $line = false)

--- a/src/PhpWord/Writer/Word2007/Part/Comments.php
+++ b/src/PhpWord/Writer/Word2007/Part/Comments.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Element\Comment;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Element\Container;
+use Shareforce\PhpWord\Element\Comment;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Writer\Word2007\Element\Container;
 
 /**
  * Word2007 comments part writer: word/comments.xml
@@ -29,7 +29,7 @@ class Comments extends AbstractPart
     /**
      * Comments collection to be written
      *
-     * @var \PhpOffice\PhpWord\Element\Comment[]
+     * @var \Shareforce\PhpWord\Element\Comment[]
      */
     protected $elements;
 
@@ -70,8 +70,8 @@ class Comments extends AbstractPart
     /**
      * Write comment item.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Comment $comment
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Comment $comment
      */
     protected function writeComment(XMLWriter $xmlWriter, Comment $comment)
     {
@@ -92,7 +92,7 @@ class Comments extends AbstractPart
     /**
      * Set element
      *
-     * @param \PhpOffice\PhpWord\Element\Comment[] $elements
+     * @param \Shareforce\PhpWord\Element\Comment[] $elements
      * @return self
      */
     public function setElements($elements)

--- a/src/PhpWord/Writer/Word2007/Part/ContentTypes.php
+++ b/src/PhpWord/Writer/Word2007/Part/ContentTypes.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Word2007 contenttypes part writer: [Content_Types].xml
@@ -31,7 +31,7 @@ class ContentTypes extends AbstractPart
      */
     public function write()
     {
-        /** @var \PhpOffice\PhpWord\Writer\Word2007 $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\Word2007 $parentWriter Type hint */
         $parentWriter = $this->getParentWriter();
         $contentTypes = $parentWriter->getContentTypes();
 
@@ -80,7 +80,7 @@ class ContentTypes extends AbstractPart
     /**
      * Write content types element
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter XML Writer
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter XML Writer
      * @param array $parts
      * @param bool $isDefault
      */

--- a/src/PhpWord/Writer/Word2007/Part/DocPropsApp.php
+++ b/src/PhpWord/Writer/Word2007/Part/DocPropsApp.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 extended document properties part writer: docProps/app.xml

--- a/src/PhpWord/Writer/Word2007/Part/DocPropsCore.php
+++ b/src/PhpWord/Writer/Word2007/Part/DocPropsCore.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 core document properties part writer: docProps/core.xml

--- a/src/PhpWord/Writer/Word2007/Part/DocPropsCustom.php
+++ b/src/PhpWord/Writer/Word2007/Part/DocPropsCustom.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 custom document properties part writer: docProps/custom.xml

--- a/src/PhpWord/Writer/Word2007/Part/Document.php
+++ b/src/PhpWord/Writer/Word2007/Part/Document.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Element\Container;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Section as SectionStyleWriter;
+use Shareforce\PhpWord\Element\Section;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Writer\Word2007\Element\Container;
+use Shareforce\PhpWord\Writer\Word2007\Style\Section as SectionStyleWriter;
 
 /**
  * Word2007 document part writer: word/document.xml
@@ -80,8 +80,8 @@ class Document extends AbstractPart
     /**
      * Write begin section.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Section $section
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Section $section
      */
     private function writeSection(XMLWriter $xmlWriter, Section $section)
     {
@@ -95,8 +95,8 @@ class Document extends AbstractPart
     /**
      * Write end section.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Section $section
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Section $section
      */
     private function writeSectionSettings(XMLWriter $xmlWriter, Section $section)
     {

--- a/src/PhpWord/Writer/Word2007/Part/Endnotes.php
+++ b/src/PhpWord/Writer/Word2007/Part/Endnotes.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 endnotes part writer: word/endnotes.xml

--- a/src/PhpWord/Writer/Word2007/Part/FontTable.php
+++ b/src/PhpWord/Writer/Word2007/Part/FontTable.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 font table writer: word/fontTable.xml

--- a/src/PhpWord/Writer/Word2007/Part/Footer.php
+++ b/src/PhpWord/Writer/Word2007/Part/Footer.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Writer\Word2007\Element\Container;
+use Shareforce\PhpWord\Writer\Word2007\Element\Container;
 
 /**
  * Word2007 footer part writer: word/footerx.xml
@@ -34,7 +34,7 @@ class Footer extends AbstractPart
     /**
      * Footer/header element to be written
      *
-     * @var \PhpOffice\PhpWord\Element\Footer
+     * @var \Shareforce\PhpWord\Element\Footer
      */
     protected $element;
 
@@ -71,7 +71,7 @@ class Footer extends AbstractPart
     /**
      * Set element
      *
-     * @param \PhpOffice\PhpWord\Element\Footer|\PhpOffice\PhpWord\Element\Header $element
+     * @param \Shareforce\PhpWord\Element\Footer|\Shareforce\PhpWord\Element\Header $element
      * @return self
      */
     public function setElement($element)

--- a/src/PhpWord/Writer/Word2007/Part/Footnotes.php
+++ b/src/PhpWord/Writer/Word2007/Part/Footnotes.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Element\Footnote;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Element\Container;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Element\Footnote;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Writer\Word2007\Element\Container;
+use Shareforce\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * Word2007 footnotes part writer: word/(footnotes|endnotes).xml
@@ -58,7 +58,7 @@ class Footnotes extends AbstractPart
     /**
      * Footnotes/endnotes collection to be written
      *
-     * @var \PhpOffice\PhpWord\Collection\Footnotes|\PhpOffice\PhpWord\Collection\Endnotes
+     * @var \Shareforce\PhpWord\Collection\Footnotes|\Shareforce\PhpWord\Collection\Endnotes
      */
     protected $elements;
 
@@ -122,7 +122,7 @@ class Footnotes extends AbstractPart
     /**
      * Set element
      *
-     * @param \PhpOffice\PhpWord\Collection\Footnotes|\PhpOffice\PhpWord\Collection\Endnotes $elements
+     * @param \Shareforce\PhpWord\Collection\Footnotes|\Shareforce\PhpWord\Collection\Endnotes $elements
      * @return self
      */
     public function setElements($elements)
@@ -135,8 +135,8 @@ class Footnotes extends AbstractPart
     /**
      * Write note item.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\Footnote|\PhpOffice\PhpWord\Element\Endnote $element
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Element\Footnote|\Shareforce\PhpWord\Element\Endnote $element
      */
     protected function writeNote(XMLWriter $xmlWriter, $element)
     {

--- a/src/PhpWord/Writer/Word2007/Part/Header.php
+++ b/src/PhpWord/Writer/Word2007/Part/Header.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 header part writer: word/headerx.xml

--- a/src/PhpWord/Writer/Word2007/Part/Numbering.php
+++ b/src/PhpWord/Writer/Word2007/Part/Numbering.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Numbering as NumberingStyle;
-use PhpOffice\PhpWord\Style\NumberingLevel;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Numbering as NumberingStyle;
+use Shareforce\PhpWord\Style\NumberingLevel;
 
 /**
  * Word2007 numbering part writer: word/numbering.xml
@@ -97,8 +97,8 @@ class Numbering extends AbstractPart
     /**
      * Write level.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\NumberingLevel $level
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\NumberingLevel $level
      */
     private function writeLevel(XMLWriter $xmlWriter, NumberingLevel $level)
     {
@@ -137,8 +137,8 @@ class Numbering extends AbstractPart
      *
      * @since 0.11.0
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\NumberingLevel $level
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\NumberingLevel $level
      * @todo Use paragraph style writer
      */
     private function writeParagraph(XMLWriter $xmlWriter, NumberingLevel $level)
@@ -169,8 +169,8 @@ class Numbering extends AbstractPart
      *
      * @since 0.11.0
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\NumberingLevel $level
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\NumberingLevel $level
      * @todo Use font style writer
      */
     private function writeFont(XMLWriter $xmlWriter, NumberingLevel $level)

--- a/src/PhpWord/Writer/Word2007/Part/Rels.php
+++ b/src/PhpWord/Writer/Word2007/Part/Rels.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Exception\Exception;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Exception\Exception;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Word2007 main relationship writer: _rels/.rels
@@ -49,7 +49,7 @@ class Rels extends AbstractPart
     /**
      * Write relationships.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param array $xmlRels
      * @param array $mediaRels
      * @param int $relId
@@ -76,7 +76,7 @@ class Rels extends AbstractPart
     /**
      * Write media relationships.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param int $relId
      * @param array $mediaRel
      */
@@ -101,13 +101,13 @@ class Rels extends AbstractPart
      * Format:
      * <Relationship Id="rId..." Type="http://..." Target="....xml" TargetMode="..." />
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param int $relId Relationship ID
      * @param string $type Relationship type
      * @param string $target Relationship target
      * @param string $targetMode Relationship target mode
      *
-     * @throws \PhpOffice\PhpWord\Exception\Exception
+     * @throws \Shareforce\PhpWord\Exception\Exception
      */
     private function writeRel(XMLWriter $xmlWriter, $relId, $type, $target, $targetMode = '')
     {

--- a/src/PhpWord/Writer/Word2007/Part/RelsDocument.php
+++ b/src/PhpWord/Writer/Word2007/Part/RelsDocument.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 document relationship writer: word/_rels/document.xml.rels
@@ -41,7 +41,7 @@ class RelsDocument extends Rels
         );
         $xmlWriter = $this->getXmlWriter();
 
-        /** @var \PhpOffice\PhpWord\Writer\Word2007 $parentWriter Type hint */
+        /** @var \Shareforce\PhpWord\Writer\Word2007 $parentWriter Type hint */
         $parentWriter = $this->getParentWriter();
         $this->writeRels($xmlWriter, $xmlRels, $parentWriter->getRelationships());
 

--- a/src/PhpWord/Writer/Word2007/Part/RelsPart.php
+++ b/src/PhpWord/Writer/Word2007/Part/RelsPart.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 part relationship writer: word/_rels/(header|footer|footnotes|endnotes)*.xml.rels

--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\ComplexType\ProofState;
-use PhpOffice\PhpWord\ComplexType\TrackChangesView;
-use PhpOffice\PhpWord\Shared\Microsoft\PasswordEncoder;
-use PhpOffice\PhpWord\Style\Language;
+use Shareforce\PhpWord\ComplexType\ProofState;
+use Shareforce\PhpWord\ComplexType\TrackChangesView;
+use Shareforce\PhpWord\Shared\Microsoft\PasswordEncoder;
+use Shareforce\PhpWord\Style\Language;
 
 /**
  * Word2007 settings part writer: word/settings.xml
@@ -69,7 +69,7 @@ class Settings extends AbstractPart
     /**
      * Write indivual setting, recursive to any child settings.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $settingKey
      * @param array|string $settingValue
      */
@@ -99,7 +99,7 @@ class Settings extends AbstractPart
      */
     private function getSettings()
     {
-        /** @var \PhpOffice\PhpWord\Metadata\Settings $documentSettings */
+        /** @var \Shareforce\PhpWord\Metadata\Settings $documentSettings */
         $documentSettings = $this->getParentWriter()->getPhpWord()->getSettings();
 
         // Default settings
@@ -181,7 +181,7 @@ class Settings extends AbstractPart
     /**
      * Get protection settings.
      *
-     * @param \PhpOffice\PhpWord\Metadata\Protection $documentProtection
+     * @param \Shareforce\PhpWord\Metadata\Protection $documentProtection
      */
     private function setDocumentProtection($documentProtection)
     {

--- a/src/PhpWord/Writer/Word2007/Part/Styles.php
+++ b/src/PhpWord/Writer/Word2007/Part/Styles.php
@@ -15,16 +15,16 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Font as FontStyle;
-use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
-use PhpOffice\PhpWord\Style\Table as TableStyle;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Font as FontStyleWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
-use PhpOffice\PhpWord\Writer\Word2007\Style\Table as TableStyleWriter;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Font as FontStyle;
+use Shareforce\PhpWord\Style\Paragraph as ParagraphStyle;
+use Shareforce\PhpWord\Style\Table as TableStyle;
+use Shareforce\PhpWord\Writer\Word2007\Style\Font as FontStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
+use Shareforce\PhpWord\Writer\Word2007\Style\Table as TableStyleWriter;
 
 /**
  * Word2007 styles part writer: word/styles.xml
@@ -76,8 +76,8 @@ class Styles extends AbstractPart
     /**
      * Write default font and other default styles.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\AbstractStyle[] $styles
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\AbstractStyle[] $styles
      */
     private function writeDefaultStyles(XMLWriter $xmlWriter, $styles)
     {
@@ -161,9 +161,9 @@ class Styles extends AbstractPart
     /**
      * Write font style.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $styleName
-     * @param \PhpOffice\PhpWord\Style\Font $style
+     * @param \Shareforce\PhpWord\Style\Font $style
      */
     private function writeFontStyle(XMLWriter $xmlWriter, $styleName, FontStyle $style)
     {
@@ -229,9 +229,9 @@ class Styles extends AbstractPart
     /**
      * Write paragraph style.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $styleName
-     * @param \PhpOffice\PhpWord\Style\Paragraph $style
+     * @param \Shareforce\PhpWord\Style\Paragraph $style
      */
     private function writeParagraphStyle(XMLWriter $xmlWriter, $styleName, ParagraphStyle $style)
     {
@@ -261,9 +261,9 @@ class Styles extends AbstractPart
     /**
      * Write table style.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $styleName
-     * @param \PhpOffice\PhpWord\Style\Table $style
+     * @param \Shareforce\PhpWord\Style\Table $style
      */
     private function writeTableStyle(XMLWriter $xmlWriter, $styleName, TableStyle $style)
     {

--- a/src/PhpWord/Writer/Word2007/Part/Theme.php
+++ b/src/PhpWord/Writer/Word2007/Part/Theme.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 theme writer: word/theme/theme1.xml

--- a/src/PhpWord/Writer/Word2007/Part/WebSettings.php
+++ b/src/PhpWord/Writer/Word2007/Part/WebSettings.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
 /**
  * Word2007 web settings part writer: word/webSettings.xml

--- a/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
+++ b/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Style writer
@@ -30,14 +30,14 @@ abstract class AbstractStyle
     /**
      * XML writer
      *
-     * @var \PhpOffice\PhpWord\Shared\XMLWriter
+     * @var \Shareforce\PhpWord\Shared\XMLWriter
      */
     private $xmlWriter;
 
     /**
      * Style; set protected for a while
      *
-     * @var string|\PhpOffice\PhpWord\Style\AbstractStyle
+     * @var string|\Shareforce\PhpWord\Style\AbstractStyle
      */
     protected $style;
 
@@ -49,8 +49,8 @@ abstract class AbstractStyle
     /**
      * Create new instance.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param string|\PhpOffice\PhpWord\Style\AbstractStyle $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param string|\Shareforce\PhpWord\Style\AbstractStyle $style
      */
     public function __construct(XMLWriter $xmlWriter, $style = null)
     {
@@ -61,7 +61,7 @@ abstract class AbstractStyle
     /**
      * Get XML Writer
      *
-     * @return \PhpOffice\PhpWord\Shared\XMLWriter
+     * @return \Shareforce\PhpWord\Shared\XMLWriter
      */
     protected function getXmlWriter()
     {
@@ -71,7 +71,7 @@ abstract class AbstractStyle
     /**
      * Get Style
      *
-     * @return string|\PhpOffice\PhpWord\Style\AbstractStyle
+     * @return string|\Shareforce\PhpWord\Style\AbstractStyle
      */
     protected function getStyle()
     {
@@ -106,16 +106,16 @@ abstract class AbstractStyle
     /**
      * Write child style.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $name
      * @param mixed $value
      */
     protected function writeChildStyle(XMLWriter $xmlWriter, $name, $value)
     {
         if ($value !== null) {
-            $class = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Style\\' . $name;
+            $class = 'Shareforce\\PhpWord\\Writer\\Word2007\\Style\\' . $name;
 
-            /** @var \PhpOffice\PhpWord\Writer\Word2007\Style\AbstractStyle $writer */
+            /** @var \Shareforce\PhpWord\Writer\Word2007\Style\AbstractStyle $writer */
             $writer = new $class($xmlWriter, $value);
             $writer->write();
         }

--- a/src/PhpWord/Writer/Word2007/Style/Cell.php
+++ b/src/PhpWord/Writer/Word2007/Style/Cell.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Style\Cell as CellStyle;
+use Shareforce\PhpWord\Style\Cell as CellStyle;
 
 /**
  * Cell style writer

--- a/src/PhpWord/Writer/Word2007/Style/Extrusion.php
+++ b/src/PhpWord/Writer/Word2007/Style/Extrusion.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * 3D extrusion style writer
@@ -30,7 +30,7 @@ class Extrusion extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Extrusion) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Extrusion) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/Fill.php
+++ b/src/PhpWord/Writer/Word2007/Style/Fill.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Fill style writer
@@ -30,7 +30,7 @@ class Fill extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Fill) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Fill) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/Font.php
+++ b/src/PhpWord/Writer/Word2007/Style/Font.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Font style writer
@@ -44,8 +44,8 @@ class Font extends AbstractStyle
             $xmlWriter->startElement('w:rStyle');
             $xmlWriter->writeAttribute('w:val', $this->style);
             $xmlWriter->endElement();
-            $style = \PhpOffice\PhpWord\Style::getStyle($this->style);
-            if ($style instanceof \PhpOffice\PhpWord\Style\Font) {
+            $style = \Shareforce\PhpWord\Style::getStyle($this->style);
+            if ($style instanceof \Shareforce\PhpWord\Style\Font) {
                 $xmlWriter->writeElementIf($style->isRTL(), 'w:rtl');
             }
             $xmlWriter->endElement();
@@ -60,7 +60,7 @@ class Font extends AbstractStyle
     private function writeStyle()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Font) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Font) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Style/Frame.php
+++ b/src/PhpWord/Writer/Word2007/Style/Frame.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style\Frame as FrameStyle;
-use PhpOffice\PhpWord\Writer\Word2007\Element\ParagraphAlignment;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style\Frame as FrameStyle;
+use Shareforce\PhpWord\Writer\Word2007\Element\ParagraphAlignment;
 
 /**
  * Frame style writer
@@ -108,8 +108,8 @@ class Frame extends AbstractStyle
     /**
      * Write wrap.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Frame $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Frame $style
      * @param string $wrap
      */
     private function writeWrap(XMLWriter $xmlWriter, FrameStyle $style, $wrap)
@@ -149,7 +149,7 @@ class Frame extends AbstractStyle
     /**
      * Get style values in associative array
      *
-     * @param \PhpOffice\PhpWord\Style\Frame $style
+     * @param \Shareforce\PhpWord\Style\Frame $style
      * @param array $properties
      * @param string $suffix
      * @return array

--- a/src/PhpWord/Writer/Word2007/Style/Image.php
+++ b/src/PhpWord/Writer/Word2007/Style/Image.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Image style writer

--- a/src/PhpWord/Writer/Word2007/Style/Indentation.php
+++ b/src/PhpWord/Writer/Word2007/Style/Indentation.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Paragraph indentation style writer
@@ -30,7 +30,7 @@ class Indentation extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Indentation) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Indentation) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/Line.php
+++ b/src/PhpWord/Writer/Word2007/Style/Line.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Style\Line as LineStyle;
+use Shareforce\PhpWord\Style\Line as LineStyle;
 
 /**
  * Line style writer

--- a/src/PhpWord/Writer/Word2007/Style/LineNumbering.php
+++ b/src/PhpWord/Writer/Word2007/Style/LineNumbering.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Line numbering style writer
@@ -31,7 +31,7 @@ class LineNumbering extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\LineNumbering) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\LineNumbering) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
+++ b/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
  * Margin border style writer
@@ -78,7 +78,7 @@ class MarginBorder extends AbstractStyle
     /**
      * Write side.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $side
      * @param int $width
      * @param string $color

--- a/src/PhpWord/Writer/Word2007/Style/Outline.php
+++ b/src/PhpWord/Writer/Word2007/Style/Outline.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Outline style writer
@@ -30,7 +30,7 @@ class Outline extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Outline) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Outline) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/Paragraph.php
+++ b/src/PhpWord/Writer/Word2007/Style/Paragraph.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
-use PhpOffice\PhpWord\Writer\Word2007\Element\ParagraphAlignment;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Paragraph as ParagraphStyle;
+use Shareforce\PhpWord\Writer\Word2007\Element\ParagraphAlignment;
 
 /**
  * Paragraph style writer
@@ -147,8 +147,8 @@ class Paragraph extends AbstractStyle
     /**
      * Write tabs.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Tab[] $tabs
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Tab[] $tabs
      */
     private function writeTabs(XMLWriter $xmlWriter, $tabs)
     {
@@ -165,7 +165,7 @@ class Paragraph extends AbstractStyle
     /**
      * Write numbering.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param array $numbering
      */
     private function writeNumbering(XMLWriter $xmlWriter, $numbering)
@@ -173,7 +173,7 @@ class Paragraph extends AbstractStyle
         $numStyle = $numbering['style'];
         $numLevel = $numbering['level'];
 
-        /** @var \PhpOffice\PhpWord\Style\Numbering $numbering */
+        /** @var \Shareforce\PhpWord\Style\Numbering $numbering */
         $numbering = Style::getStyle($numStyle);
         if ($numStyle !== null && $numbering !== null) {
             $xmlWriter->startElement('w:numPr');

--- a/src/PhpWord/Writer/Word2007/Style/Row.php
+++ b/src/PhpWord/Writer/Word2007/Style/Row.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Row style writer
@@ -35,7 +35,7 @@ class Row extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Row) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Row) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Style/Section.php
+++ b/src/PhpWord/Writer/Word2007/Style/Section.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Style\Section as SectionStyle;
+use Shareforce\PhpWord\Style\Section as SectionStyle;
 
 /**
  * Section style writer

--- a/src/PhpWord/Writer/Word2007/Style/Shading.php
+++ b/src/PhpWord/Writer/Word2007/Style/Shading.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Shading style writer
@@ -30,7 +30,7 @@ class Shading extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Shading) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Shading) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/Shadow.php
+++ b/src/PhpWord/Writer/Word2007/Style/Shadow.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Shadow style writer
@@ -30,7 +30,7 @@ class Shadow extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Shadow) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Shadow) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/Shape.php
+++ b/src/PhpWord/Writer/Word2007/Style/Shape.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Shape style writer
@@ -30,7 +30,7 @@ class Shape extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Shape) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Shape) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Style/Spacing.php
+++ b/src/PhpWord/Writer/Word2007/Style/Spacing.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Spacing between lines and above/below paragraph style writer
@@ -30,7 +30,7 @@ class Spacing extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Spacing) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Spacing) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();
@@ -46,7 +46,7 @@ class Spacing extends AbstractStyle
         $line = $style->getLine();
         //if linerule is auto, the spacing is supposed to include the height of the line itself, which is 240 twips
         if (null !== $line && 'auto' === $style->getLineRule()) {
-            $line += \PhpOffice\PhpWord\Style\Paragraph::LINE_HEIGHT;
+            $line += \Shareforce\PhpWord\Style\Paragraph::LINE_HEIGHT;
         }
         $xmlWriter->writeAttributeIf(!is_null($line), 'w:line', $line);
 

--- a/src/PhpWord/Writer/Word2007/Style/Tab.php
+++ b/src/PhpWord/Writer/Word2007/Style/Tab.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * Line numbering style writer
@@ -30,7 +30,7 @@ class Tab extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Tab) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\Tab) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/Table.php
+++ b/src/PhpWord/Writer/Word2007/Style/Table.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\SimpleType\TblWidth;
-use PhpOffice\PhpWord\Style\Table as TableStyle;
-use PhpOffice\PhpWord\Writer\Word2007\Element\TableAlignment;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\SimpleType\TblWidth;
+use Shareforce\PhpWord\Style\Table as TableStyle;
+use Shareforce\PhpWord\Writer\Word2007\Element\TableAlignment;
 
 /**
  * Table style writer
@@ -59,8 +59,8 @@ class Table extends AbstractStyle
     /**
      * Write full style.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Table $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Table $style
      */
     private function writeStyle(XMLWriter $xmlWriter, TableStyle $style)
     {
@@ -106,7 +106,7 @@ class Table extends AbstractStyle
     /**
      * Enable/Disable automatic resizing of the table
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $layout autofit / fixed
      */
     private function writeLayout(XMLWriter $xmlWriter, $layout)
@@ -119,8 +119,8 @@ class Table extends AbstractStyle
     /**
      * Write margin.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Table $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Table $style
      */
     private function writeMargin(XMLWriter $xmlWriter, TableStyle $style)
     {
@@ -138,8 +138,8 @@ class Table extends AbstractStyle
     /**
      * Write border.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Table $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Table $style
      */
     private function writeBorder(XMLWriter $xmlWriter, TableStyle $style)
     {
@@ -158,7 +158,7 @@ class Table extends AbstractStyle
     /**
      * Writes a table width
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
      * @param string $elementName
      * @param string $unit
      * @param int|float $width
@@ -177,8 +177,8 @@ class Table extends AbstractStyle
     /**
      * Write row style.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Table $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Table $style
      */
     private function writeFirstRow(XMLWriter $xmlWriter, TableStyle $style)
     {
@@ -196,8 +196,8 @@ class Table extends AbstractStyle
     /**
      * Write shading.
      *
-     * @param \PhpOffice\PhpWord\Shared\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Style\Table $style
+     * @param \Shareforce\PhpWord\Shared\XMLWriter $xmlWriter
+     * @param \Shareforce\PhpWord\Style\Table $style
      */
     private function writeShading(XMLWriter $xmlWriter, TableStyle $style)
     {

--- a/src/PhpWord/Writer/Word2007/Style/TablePosition.php
+++ b/src/PhpWord/Writer/Word2007/Style/TablePosition.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
 /**
  * TablePosition style writer
@@ -28,7 +28,7 @@ class TablePosition extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\TablePosition) {
+        if (!$style instanceof \Shareforce\PhpWord\Style\TablePosition) {
             return;
         }
 

--- a/src/PhpWord/Writer/Word2007/Style/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Style/TextBox.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Style\TextBox as TextBoxStyle;
+use Shareforce\PhpWord\Style\TextBox as TextBoxStyle;
 
 /**
  * TextBox style writer

--- a/src/PhpWord/Writer/WriterInterface.php
+++ b/src/PhpWord/Writer/WriterInterface.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
 /**
  * Writer interface

--- a/tests/PhpWord/Collection/CollectionTest.php
+++ b/tests/PhpWord/Collection/CollectionTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Collection;
+namespace Shareforce\PhpWord\Collection;
 
-use PhpOffice\PhpWord\Element\Footnote;
+use Shareforce\PhpWord\Element\Footnote;
 
 /**
- * Test class for PhpOffice\PhpWord\Collection subnamespace
+ * Test class for Shareforce\PhpWord\Collection subnamespace
  *
  * Using concrete class Footnotes instead of AbstractCollection
  */
@@ -36,7 +36,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(2, $object->addItem(new Footnote())); // addItem #2. Should returns new item index
         $this->assertCount(2, $object->getItems()); // getItems returns array
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Footnote', $object->getItem(1)); // getItem returns object
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Footnote', $object->getItem(1)); // getItem returns object
         $this->assertNull($object->getItem(3)); // getItem returns null when invalid index is referenced
 
         $object->setItem(2, null); // Set item #2 to null

--- a/tests/PhpWord/ComplexType/FootnotePropertiesTest.php
+++ b/tests/PhpWord/ComplexType/FootnotePropertiesTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\ComplexType;
+namespace Shareforce\PhpWord\ComplexType;
 
-use PhpOffice\PhpWord\SimpleType\NumberFormat;
+use Shareforce\PhpWord\SimpleType\NumberFormat;
 
 /**
- * Test class for PhpOffice\PhpWord\ComplexType\FootnoteProperties
+ * Test class for Shareforce\PhpWord\ComplexType\FootnoteProperties
  *
- * @coversDefaultClass \PhpOffice\PhpWord\ComplexType\FootnoteProperties
+ * @coversDefaultClass \Shareforce\PhpWord\ComplexType\FootnoteProperties
  * @runTestsInSeparateProcesses
  */
 class FootnotePropertiesTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/ComplexType/ProofStateTest.php
+++ b/tests/PhpWord/ComplexType/ProofStateTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\ComplexType;
+namespace Shareforce\PhpWord\ComplexType;
 
 /**
- * Test class for PhpOffice\PhpWord\ComplexType\ProofState
+ * Test class for Shareforce\PhpWord\ComplexType\ProofState
  *
- * @coversDefaultClass \PhpOffice\PhpWord\ComplexType\ProofState
+ * @coversDefaultClass \Shareforce\PhpWord\ComplexType\ProofState
  */
 class ProofStateTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Element/AbstractElementTest.php
+++ b/tests/PhpWord/Element/AbstractElementTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\AbstractElement
+ * Test class for Shareforce\PhpWord\Element\AbstractElement
  */
 class AbstractElementTest extends \PHPUnit\Framework\TestCase
 {
@@ -27,7 +27,7 @@ class AbstractElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testElementIndex()
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Element\AbstractElement');
+        $stub = $this->getMockForAbstractClass('\Shareforce\PhpWord\Element\AbstractElement');
         $ival = rand(0, 100);
         $stub->setElementIndex($ival);
         $this->assertEquals($ival, $stub->getElementIndex());
@@ -38,7 +38,7 @@ class AbstractElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testElementId()
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Element\AbstractElement');
+        $stub = $this->getMockForAbstractClass('\Shareforce\PhpWord\Element\AbstractElement');
         $stub->setElementId();
         $this->assertEquals(6, strlen($stub->getElementId()));
     }

--- a/tests/PhpWord/Element/BookmarkTest.php
+++ b/tests/PhpWord/Element/BookmarkTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Footer
+ * Test class for Shareforce\PhpWord\Element\Footer
  *
  * @runTestsInSeparateProcesses
  */
@@ -32,7 +32,7 @@ class BookmarkTest extends \PHPUnit\Framework\TestCase
         $bookmarkName = 'test';
         $oBookmark = new Bookmark($bookmarkName);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Bookmark', $oBookmark);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Bookmark', $oBookmark);
         $this->assertEquals($bookmarkName, $oBookmark->getName());
     }
 }

--- a/tests/PhpWord/Element/CellTest.php
+++ b/tests/PhpWord/Element/CellTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\AbstractWebServerEmbeddedTest;
+use Shareforce\PhpWord\AbstractWebServerEmbeddedTest;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Cell
+ * Test class for Shareforce\PhpWord\Element\Cell
  *
  * @runTestsInSeparateProcesses
  */
@@ -33,7 +33,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
     {
         $oCell = new Cell();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Cell', $oCell);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Cell', $oCell);
         $this->assertNull($oCell->getWidth());
     }
 
@@ -44,7 +44,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
     {
         $oCell = new Cell(null, array('valign' => 'center'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Cell', $oCell->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Cell', $oCell->getStyle());
         $this->assertNull($oCell->getWidth());
     }
 
@@ -57,7 +57,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addText('text');
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
     }
 
     /**
@@ -69,7 +69,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addText(utf8_decode('ééé'));
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertEquals('ééé', $element->getText());
     }
 
@@ -82,7 +82,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addLink(utf8_decode('ééé'), utf8_decode('ééé'));
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $element);
     }
 
     /**
@@ -105,7 +105,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addListItem('text');
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\ListItem', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\ListItem', $element);
         $this->assertEquals('text', $element->getTextObject()->getText());
     }
 
@@ -118,7 +118,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addListItem(utf8_decode('ééé'));
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\ListItem', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\ListItem', $element);
         $this->assertEquals('ééé', $element->getTextObject()->getText());
     }
 
@@ -132,7 +132,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addImage($src);
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -145,7 +145,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addImage($src);
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -158,7 +158,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addImage($src);
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -170,7 +170,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addImage(self::getRemoteGifImageUrl());
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -183,13 +183,13 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addObject($src);
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\OLEObject', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\OLEObject', $element);
     }
 
     /**
      * Test add object exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidObjectException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidObjectException
      */
     public function testAddObjectException()
     {
@@ -208,7 +208,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addPreserveText('text');
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PreserveText', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PreserveText', $element);
     }
 
     /**
@@ -221,7 +221,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addPreserveText(utf8_decode('ééé'));
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PreserveText', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PreserveText', $element);
         $this->assertEquals(array('ééé'), $element->getText());
     }
 
@@ -246,7 +246,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addTextRun();
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $element);
     }
 
     /**
@@ -258,7 +258,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $element = $oCell->addCheckBox(utf8_decode('ééé'), utf8_decode('ééé'));
 
         $this->assertCount(1, $oCell->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\CheckBox', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\CheckBox', $element);
     }
 
     /**

--- a/tests/PhpWord/Element/CheckBoxTest.php
+++ b/tests/PhpWord/Element/CheckBoxTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\Style\Font;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\Style\Font;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\CheckBox
+ * Test class for Shareforce\PhpWord\Element\CheckBox
  *
  * @runTestsInSeparateProcesses
  */
@@ -34,10 +34,10 @@ class CheckBoxTest extends \PHPUnit\Framework\TestCase
     {
         $oCheckBox = new CheckBox();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\CheckBox', $oCheckBox);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\CheckBox', $oCheckBox);
         $this->assertNull($oCheckBox->getText());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $oCheckBox->getFontStyle());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oCheckBox->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $oCheckBox->getFontStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oCheckBox->getParagraphStyle());
     }
 
     /**
@@ -60,7 +60,7 @@ class CheckBoxTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('fontStyle', $oCheckBox->getFontStyle());
 
         $oCheckBox->setFontStyle(array('bold' => true, 'italic' => true, 'size' => 16));
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $oCheckBox->getFontStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $oCheckBox->getFontStyle());
     }
 
     /**
@@ -82,6 +82,6 @@ class CheckBoxTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('paragraphStyle', $oCheckBox->getParagraphStyle());
 
         $oCheckBox->setParagraphStyle(array('alignment' => Jc::CENTER, 'spaceAfter' => 100));
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oCheckBox->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oCheckBox->getParagraphStyle());
     }
 }

--- a/tests/PhpWord/Element/CommentTest.php
+++ b/tests/PhpWord/Element/CommentTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Header
+ * Test class for Shareforce\PhpWord\Element\Header
  *
  * @runTestsInSeparateProcesses
  */
@@ -38,7 +38,7 @@ class CommentTest extends \PHPUnit\Framework\TestCase
         $oComment->setStartElement($oText);
         $oComment->setEndElement($oText);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Comment', $oComment);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Comment', $oComment);
         $this->assertEquals($author, $oComment->getAuthor());
         $this->assertEquals($date, $oComment->getDate());
         $this->assertEquals($initials, $oComment->getInitials());
@@ -54,7 +54,7 @@ class CommentTest extends \PHPUnit\Framework\TestCase
         $oComment = new Comment('Test User', new \DateTime(), 'my_initials');
         $element = $oComment->addText('text');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertCount(1, $oComment->getElements());
         $this->assertEquals('text', $element->getText());
     }

--- a/tests/PhpWord/Element/FieldTest.php
+++ b/tests/PhpWord/Element/FieldTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Field
+ * Test class for Shareforce\PhpWord\Element\Field
  *
  * @runTestsInSeparateProcesses
  */
@@ -31,7 +31,7 @@ class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $oField = new Field();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Field', $oField);
     }
 
     /**
@@ -41,7 +41,7 @@ class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $oField = new Field('DATE');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Field', $oField);
         $this->assertEquals('DATE', $oField->getType());
     }
 
@@ -52,7 +52,7 @@ class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $oField = new Field('DATE', array('dateformat' => 'd-M-yyyy'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Field', $oField);
         $this->assertEquals('DATE', $oField->getType());
         $this->assertEquals(array('dateformat' => 'd-M-yyyy'), $oField->getProperties());
     }
@@ -64,7 +64,7 @@ class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $oField = new Field('DATE', array('dateformat' => 'd-M-yyyy'), array('SakaEraCalendar', 'PreserveFormat'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Field', $oField);
         $this->assertEquals('DATE', $oField->getType());
         $this->assertEquals(array('dateformat' => 'd-M-yyyy'), $oField->getProperties());
         $this->assertEquals(array('SakaEraCalendar', 'PreserveFormat'), $oField->getOptions());
@@ -77,7 +77,7 @@ class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $oField = new Field('XE', array(), array('Bold', 'Italic'), 'FieldValue');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Field', $oField);
         $this->assertEquals('XE', $oField->getType());
         $this->assertEquals(array(), $oField->getProperties());
         $this->assertEquals(array('Bold', 'Italic'), $oField->getOptions());
@@ -94,18 +94,18 @@ class FieldTest extends \PHPUnit\Framework\TestCase
 
         $oField = new Field('XE', array(), array('Bold', 'Italic'), $textRun);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Field', $oField);
         $this->assertEquals('XE', $oField->getType());
         $this->assertEquals(array(), $oField->getProperties());
         $this->assertEquals(array('Bold', 'Italic'), $oField->getOptions());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $oField->getText());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $oField->getText());
     }
 
     public function testConstructWithOptionValue()
     {
         $oField = new Field('INDEX', array(), array('\\c "3" \\h "A"'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Field', $oField);
         $this->assertEquals('INDEX', $oField->getType());
         $this->assertEquals(array(), $oField->getProperties());
         $this->assertEquals(array('\\c "3" \\h "A"'), $oField->getOptions());

--- a/tests/PhpWord/Element/FooterTest.php
+++ b/tests/PhpWord/Element/FooterTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\AbstractWebServerEmbeddedTest;
+use Shareforce\PhpWord\AbstractWebServerEmbeddedTest;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Footer
+ * Test class for Shareforce\PhpWord\Element\Footer
  *
  * @runTestsInSeparateProcesses
  */
@@ -34,7 +34,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $iVal = rand(1, 1000);
         $oFooter = new Footer($iVal);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Footer', $oFooter);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Footer', $oFooter);
         $this->assertEquals($iVal, $oFooter->getSectionId());
     }
 
@@ -47,7 +47,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addText('text');
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
     }
 
     /**
@@ -59,7 +59,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addText(utf8_decode('ééé'));
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertEquals('ééé', $element->getText());
     }
 
@@ -84,7 +84,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addTextRun();
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $element);
     }
 
     /**
@@ -96,7 +96,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addTable();
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Table', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Table', $element);
     }
 
     /**
@@ -109,7 +109,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addImage($src);
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -121,7 +121,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addImage(self::getRemoteGifImageUrl());
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -133,7 +133,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addPreserveText('text');
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PreserveText', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PreserveText', $element);
     }
 
     /**
@@ -145,7 +145,7 @@ class FooterTest extends AbstractWebServerEmbeddedTest
         $element = $oFooter->addPreserveText(utf8_decode('ééé'));
 
         $this->assertCount(1, $oFooter->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PreserveText', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PreserveText', $element);
         $this->assertEquals(array('ééé'), $element->getText());
     }
 

--- a/tests/PhpWord/Element/FootnoteTest.php
+++ b/tests/PhpWord/Element/FootnoteTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Footnote
+ * Test class for Shareforce\PhpWord\Element\Footnote
  *
  * @runTestsInSeparateProcesses
  */
@@ -31,7 +31,7 @@ class FootnoteTest extends \PHPUnit\Framework\TestCase
     {
         $oFootnote = new Footnote();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Footnote', $oFootnote);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Footnote', $oFootnote);
         $this->assertCount(0, $oFootnote->getElements());
         $this->assertNull($oFootnote->getParagraphStyle());
     }
@@ -54,7 +54,7 @@ class FootnoteTest extends \PHPUnit\Framework\TestCase
         $oFootnote = new Footnote(array('spacing' => 100));
 
         $this->assertInstanceOf(
-            'PhpOffice\\PhpWord\\Style\\Paragraph',
+            'Shareforce\\PhpWord\\Style\\Paragraph',
             $oFootnote->getParagraphStyle()
         );
     }
@@ -68,7 +68,7 @@ class FootnoteTest extends \PHPUnit\Framework\TestCase
         $element = $oFootnote->addText('text');
 
         $this->assertCount(1, $oFootnote->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
     }
 
     /**
@@ -91,7 +91,7 @@ class FootnoteTest extends \PHPUnit\Framework\TestCase
         $element = $oFootnote->addLink('https://github.com/PHPOffice/PHPWord');
 
         $this->assertCount(1, $oFootnote->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $element);
     }
 
     /**

--- a/tests/PhpWord/Element/HeaderTest.php
+++ b/tests/PhpWord/Element/HeaderTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\AbstractWebServerEmbeddedTest;
+use Shareforce\PhpWord\AbstractWebServerEmbeddedTest;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Header
+ * Test class for Shareforce\PhpWord\Element\Header
  *
  * @runTestsInSeparateProcesses
  */
@@ -34,7 +34,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $iVal = rand(1, 1000);
         $oHeader = new Header($iVal);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Header', $oHeader);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Header', $oHeader);
         $this->assertEquals($iVal, $oHeader->getSectionId());
         $this->assertEquals(Header::AUTO, $oHeader->getType());
     }
@@ -47,7 +47,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $oHeader = new Header(1);
         $element = $oHeader->addText('text');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertCount(1, $oHeader->getElements());
         $this->assertEquals('text', $element->getText());
     }
@@ -60,7 +60,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $oHeader = new Header(1);
         $element = $oHeader->addText(utf8_decode('ééé'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertCount(1, $oHeader->getElements());
         $this->assertEquals('ééé', $element->getText());
     }
@@ -93,7 +93,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
     {
         $oHeader = new Header(1);
         $element = $oHeader->addTextRun();
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $element);
         $this->assertCount(1, $oHeader->getElements());
     }
 
@@ -104,7 +104,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
     {
         $oHeader = new Header(1);
         $element = $oHeader->addTable();
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Table', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Table', $element);
         $this->assertCount(1, $oHeader->getElements());
     }
 
@@ -118,7 +118,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $element = $oHeader->addImage($src);
 
         $this->assertCount(1, $oHeader->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -130,7 +130,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $element = $oHeader->addImage(self::getRemoteGifImageUrl());
 
         $this->assertCount(1, $oHeader->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**
@@ -142,7 +142,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $element = $oHeader->addPreserveText('text');
 
         $this->assertCount(1, $oHeader->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PreserveText', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PreserveText', $element);
     }
 
     /**
@@ -154,7 +154,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $element = $oHeader->addPreserveText(utf8_decode('ééé'));
 
         $this->assertCount(1, $oHeader->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PreserveText', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PreserveText', $element);
         $this->assertEquals(array('ééé'), $element->getText());
     }
 
@@ -168,7 +168,7 @@ class HeaderTest extends AbstractWebServerEmbeddedTest
         $element = $oHeader->addWatermark($src);
 
         $this->assertCount(1, $oHeader->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
     }
 
     /**

--- a/tests/PhpWord/Element/ImageTest.php
+++ b/tests/PhpWord/Element/ImageTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\AbstractWebServerEmbeddedTest;
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\AbstractWebServerEmbeddedTest;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Image
+ * Test class for Shareforce\PhpWord\Element\Image
  *
  * @runTestsInSeparateProcesses
  */
@@ -35,12 +35,12 @@ class ImageTest extends AbstractWebServerEmbeddedTest
         $src = __DIR__ . '/../_files/images/firefox.png';
         $oImage = new Image($src);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $oImage);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $oImage);
         $this->assertEquals($src, $oImage->getSource());
         $this->assertEquals(md5($src), $oImage->getMediaId());
         $this->assertFalse($oImage->isWatermark());
         $this->assertEquals(Image::SOURCE_LOCAL, $oImage->getSourceType());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oImage->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Image', $oImage->getStyle());
     }
 
     /**
@@ -55,11 +55,11 @@ class ImageTest extends AbstractWebServerEmbeddedTest
                 'width'         => 210,
                 'height'        => 210,
                 'alignment'     => Jc::CENTER,
-                'wrappingStyle' => \PhpOffice\PhpWord\Style\Image::WRAPPING_STYLE_BEHIND,
+                'wrappingStyle' => \Shareforce\PhpWord\Style\Image::WRAPPING_STYLE_BEHIND,
             )
         );
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oImage->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Image', $oImage->getStyle());
     }
 
     /**
@@ -80,7 +80,7 @@ class ImageTest extends AbstractWebServerEmbeddedTest
             $nam = ucfirst(strtok($source, '.'));
             $source = __DIR__ . "/../_files/images/{$source}";
             $image = new Image($source, null, null, $nam);
-            $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $image);
+            $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $image);
             $this->assertEquals($source, $image->getSource());
             $this->assertEquals($nam, $image->getName());
             $this->assertEquals(md5($source), $image->getMediaId());
@@ -103,13 +103,13 @@ class ImageTest extends AbstractWebServerEmbeddedTest
             array('height' => 210, 'alignment' => Jc::CENTER)
         );
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oImage->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Image', $oImage->getStyle());
     }
 
     /**
      * Test invalid local image
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidImageException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidImageException
      */
     public function testInvalidImageLocal()
     {
@@ -119,7 +119,7 @@ class ImageTest extends AbstractWebServerEmbeddedTest
     /**
      * Test invalid PHP Image
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidImageException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidImageException
      */
     public function testInvalidImagePhp()
     {
@@ -130,7 +130,7 @@ class ImageTest extends AbstractWebServerEmbeddedTest
     /**
      * Test unsupported image
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\UnsupportedImageTypeException
+     * @expectedException \Shareforce\PhpWord\Exception\UnsupportedImageTypeException
      */
     public function testUnsupportedImage()
     {
@@ -200,7 +200,7 @@ class ImageTest extends AbstractWebServerEmbeddedTest
         $source = file_get_contents(__DIR__ . '/../_files/images/earth.jpg');
 
         $image = new Image($source);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $image);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $image);
         $this->assertEquals($source, $image->getSource());
         $this->assertEquals(md5($source), $image->getMediaId());
         $this->assertEquals('image/jpeg', $image->getImageType());
@@ -221,7 +221,7 @@ class ImageTest extends AbstractWebServerEmbeddedTest
         $source = self::getRemoteImageUrl();
 
         $image = new Image($source);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $image);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $image);
         $this->assertEquals($source, $image->getSource());
         $this->assertEquals(md5($source), $image->getMediaId());
         $this->assertEquals('image/png', $image->getImageType());
@@ -237,7 +237,7 @@ class ImageTest extends AbstractWebServerEmbeddedTest
     /**
      * Test invalid string image
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidImageException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidImageException
      */
     public function testInvalidImageString()
     {

--- a/tests/PhpWord/Element/LineTest.php
+++ b/tests/PhpWord/Element/LineTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Line
+ * Test class for Shareforce\PhpWord\Element\Line
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\Line
+ * @coversDefaultClass \Shareforce\PhpWord\Element\Line
  * @runTestsInSeparateProcesses
  */
 class LineTest extends \PHPUnit\Framework\TestCase
@@ -32,7 +32,7 @@ class LineTest extends \PHPUnit\Framework\TestCase
     {
         $oLine = new Line();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Line', $oLine);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Line', $oLine);
         $this->assertNull($oLine->getStyle());
     }
 
@@ -53,22 +53,22 @@ class LineTest extends \PHPUnit\Framework\TestCase
     {
         $oLine = new Line(
             array(
-                'width'            => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(14),
-                'height'           => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(4),
+                'width'            => \Shareforce\PhpWord\Shared\Converter::cmToPixel(14),
+                'height'           => \Shareforce\PhpWord\Shared\Converter::cmToPixel(4),
                 'positioning'      => 'absolute',
                 'posHorizontalRel' => 'page',
                 'posVerticalRel'   => 'page',
                 'flip'             => true,
-                'marginLeft'       => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(5),
-                'marginTop'        => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(3),
-                'wrappingStyle'    => \PhpOffice\PhpWord\Style\Image::WRAPPING_STYLE_SQUARE,
-                'beginArrow'       => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
-                'endArrow'         => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_OVAL,
-                'dash'             => \PhpOffice\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
+                'marginLeft'       => \Shareforce\PhpWord\Shared\Converter::cmToPixel(5),
+                'marginTop'        => \Shareforce\PhpWord\Shared\Converter::cmToPixel(3),
+                'wrappingStyle'    => \Shareforce\PhpWord\Style\Image::WRAPPING_STYLE_SQUARE,
+                'beginArrow'       => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
+                'endArrow'         => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_OVAL,
+                'dash'             => \Shareforce\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
                 'weight'           => 10,
             )
         );
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Line', $oLine->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Line', $oLine->getStyle());
     }
 }

--- a/tests/PhpWord/Element/LinkTest.php
+++ b/tests/PhpWord/Element/LinkTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Font;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Link
+ * Test class for Shareforce\PhpWord\Element\Link
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\Link
+ * @coversDefaultClass \Shareforce\PhpWord\Element\Link
  * @runTestsInSeparateProcesses
  */
 class LinkTest extends \PHPUnit\Framework\TestCase
@@ -34,7 +34,7 @@ class LinkTest extends \PHPUnit\Framework\TestCase
     {
         $oLink = new Link('https://github.com/PHPOffice/PHPWord');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $oLink);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $oLink);
         $this->assertEquals('https://github.com/PHPOffice/PHPWord', $oLink->getSource());
         $this->assertEquals($oLink->getSource(), $oLink->getText());
         $this->assertNull($oLink->getFontStyle());
@@ -53,11 +53,11 @@ class LinkTest extends \PHPUnit\Framework\TestCase
             array('marginLeft' => 600, 'marginRight' => 600, 'marginTop' => 600, 'marginBottom' => 600)
         );
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $oLink);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $oLink);
         $this->assertEquals('https://github.com/PHPOffice/PHPWord', $oLink->getSource());
         $this->assertEquals('PHPWord on GitHub', $oLink->getText());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $oLink->getFontStyle());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oLink->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $oLink->getFontStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oLink->getParagraphStyle());
     }
 
     /**

--- a/tests/PhpWord/Element/ListItemRunTest.php
+++ b/tests/PhpWord/Element/ListItemRunTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\ListItemRun
+ * Test class for Shareforce\PhpWord\Element\ListItemRun
  *
  * @runTestsInSeparateProcesses
  */
@@ -31,9 +31,9 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
     {
         $oListItemRun = new ListItemRun();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\ListItemRun', $oListItemRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\ListItemRun', $oListItemRun);
         $this->assertCount(0, $oListItemRun->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oListItemRun->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oListItemRun->getParagraphStyle());
     }
 
     /**
@@ -43,7 +43,7 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
     {
         $oListItemRun = new ListItemRun(0, null, 'pStyle');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\ListItemRun', $oListItemRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\ListItemRun', $oListItemRun);
         $this->assertCount(0, $oListItemRun->getElements());
         $this->assertEquals('pStyle', $oListItemRun->getParagraphStyle());
     }
@@ -55,7 +55,7 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
     {
         $oListItemRun = new ListItemRun(0, 'numberingStyle');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\ListItemRun', $oListItemRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\ListItemRun', $oListItemRun);
         $this->assertCount(0, $oListItemRun->getElements());
     }
 
@@ -66,9 +66,9 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
     {
         $oListItemRun = new ListItemRun(0, null, array('spacing' => 100));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\ListItemRun', $oListItemRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\ListItemRun', $oListItemRun);
         $this->assertCount(0, $oListItemRun->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oListItemRun->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oListItemRun->getParagraphStyle());
     }
 
     /**
@@ -76,10 +76,10 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
      */
     public function testStyle()
     {
-        $oListItemRun = new ListItemRun(1, array('listType' => \PhpOffice\PhpWord\Style\ListItem::TYPE_NUMBER));
+        $oListItemRun = new ListItemRun(1, array('listType' => \Shareforce\PhpWord\Style\ListItem::TYPE_NUMBER));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\ListItem', $oListItemRun->getStyle());
-        $this->assertEquals(\PhpOffice\PhpWord\Style\ListItem::TYPE_NUMBER, $oListItemRun->getStyle()->getListType());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\ListItem', $oListItemRun->getStyle());
+        $this->assertEquals(\Shareforce\PhpWord\Style\ListItem::TYPE_NUMBER, $oListItemRun->getStyle()->getListType());
     }
 
     /**
@@ -101,7 +101,7 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
         $oListItemRun = new ListItemRun();
         $element = $oListItemRun->addText('text');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertCount(1, $oListItemRun->getElements());
         $this->assertEquals('text', $element->getText());
     }
@@ -114,7 +114,7 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
         $oListItemRun = new ListItemRun();
         $element = $oListItemRun->addText(utf8_decode('ééé'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertCount(1, $oListItemRun->getElements());
         $this->assertEquals('ééé', $element->getText());
     }
@@ -127,7 +127,7 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
         $oListItemRun = new ListItemRun();
         $element = $oListItemRun->addLink('https://github.com/PHPOffice/PHPWord');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $element);
         $this->assertCount(1, $oListItemRun->getElements());
         $this->assertEquals('https://github.com/PHPOffice/PHPWord', $element->getSource());
     }
@@ -140,7 +140,7 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
         $oListItemRun = new ListItemRun();
         $element = $oListItemRun->addLink('https://github.com/PHPOffice/PHPWord', 'PHPWord on GitHub');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $element);
         $this->assertCount(1, $oListItemRun->getElements());
         $this->assertEquals('https://github.com/PHPOffice/PHPWord', $element->getSource());
         $this->assertEquals('PHPWord on GitHub', $element->getText());
@@ -167,7 +167,7 @@ class ListItemRunTest extends \PHPUnit\Framework\TestCase
         $oListItemRun = new ListItemRun();
         $element = $oListItemRun->addImage($src);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
         $this->assertCount(1, $oListItemRun->getElements());
     }
 }

--- a/tests/PhpWord/Element/ListItemTest.php
+++ b/tests/PhpWord/Element/ListItemTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\ListItem
+ * Test class for Shareforce\PhpWord\Element\ListItem
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\ListItem
+ * @coversDefaultClass \Shareforce\PhpWord\Element\ListItem
  * @runTestsInSeparateProcesses
  */
 class ListItemTest extends \PHPUnit\Framework\TestCase
@@ -32,7 +32,7 @@ class ListItemTest extends \PHPUnit\Framework\TestCase
     {
         $oListItem = new ListItem('text');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $oListItem->getTextObject());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $oListItem->getTextObject());
     }
 
     /**
@@ -40,10 +40,10 @@ class ListItemTest extends \PHPUnit\Framework\TestCase
      */
     public function testStyle()
     {
-        $oListItem = new ListItem('text', 1, null, array('listType' => \PhpOffice\PhpWord\Style\ListItem::TYPE_NUMBER));
+        $oListItem = new ListItem('text', 1, null, array('listType' => \Shareforce\PhpWord\Style\ListItem::TYPE_NUMBER));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\ListItem', $oListItem->getStyle());
-        $this->assertEquals(\PhpOffice\PhpWord\Style\ListItem::TYPE_NUMBER, $oListItem->getStyle()->getListType());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\ListItem', $oListItem->getStyle());
+        $this->assertEquals(\Shareforce\PhpWord\Style\ListItem::TYPE_NUMBER, $oListItem->getStyle()->getListType());
     }
 
     /**

--- a/tests/PhpWord/Element/ObjectTest.php
+++ b/tests/PhpWord/Element/ObjectTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\OLEObject
+ * Test class for Shareforce\PhpWord\Element\OLEObject
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\OLEObject
+ * @coversDefaultClass \Shareforce\PhpWord\Element\OLEObject
  * @runTestsInSeparateProcesses
  */
 class ObjectTest extends \PHPUnit\Framework\TestCase
@@ -33,8 +33,8 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
         $src = __DIR__ . '/../_files/documents/reader.docx';
         $oObject = new OLEObject($src);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\OLEObject', $oObject);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oObject->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\OLEObject', $oObject);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Image', $oObject->getStyle());
         $this->assertEquals($src, $oObject->getSource());
     }
 
@@ -46,15 +46,15 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
         $src = __DIR__ . '/../_files/documents/sheet.xls';
         $oObject = new OLEObject($src);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\OLEObject', $oObject);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oObject->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\OLEObject', $oObject);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Image', $oObject->getStyle());
         $this->assertEquals($src, $oObject->getSource());
     }
 
     /**
      * Create new instance with non-supported files
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidObjectException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidObjectException
      */
     public function testConstructWithNotSupportedFiles()
     {
@@ -71,8 +71,8 @@ class ObjectTest extends \PHPUnit\Framework\TestCase
         $src = __DIR__ . '/../_files/documents/sheet.xls';
         $oObject = new OLEObject($src, array('width' => '230px'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\OLEObject', $oObject);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oObject->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\OLEObject', $oObject);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Image', $oObject->getStyle());
         $this->assertEquals($src, $oObject->getSource());
     }
 

--- a/tests/PhpWord/Element/PageBreakTest.php
+++ b/tests/PhpWord/Element/PageBreakTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\PageBreak
+ * Test class for Shareforce\PhpWord\Element\PageBreak
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\PageBreak
+ * @coversDefaultClass \Shareforce\PhpWord\Element\PageBreak
  * @runTestsInSeparateProcesses
  */
 class PageBreakTest extends \PHPUnit\Framework\TestCase
@@ -32,6 +32,6 @@ class PageBreakTest extends \PHPUnit\Framework\TestCase
     {
         $oPageBreak = new PageBreak();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PageBreak', $oPageBreak);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PageBreak', $oPageBreak);
     }
 }

--- a/tests/PhpWord/Element/PreserveTextTest.php
+++ b/tests/PhpWord/Element/PreserveTextTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\PreserveText
+ * Test class for Shareforce\PhpWord\Element\PreserveText
  *
  * @runTestsInSeparateProcesses
  */
@@ -33,7 +33,7 @@ class PreserveTextTest extends \PHPUnit\Framework\TestCase
     {
         $oPreserveText = new PreserveText();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\PreserveText', $oPreserveText);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\PreserveText', $oPreserveText);
         $this->assertNull($oPreserveText->getText());
         $this->assertNull($oPreserveText->getFontStyle());
         $this->assertNull($oPreserveText->getParagraphStyle());
@@ -56,7 +56,7 @@ class PreserveTextTest extends \PHPUnit\Framework\TestCase
     public function testConstructWithArray()
     {
         $oPreserveText = new PreserveText('text', array('size' => 16, 'color' => '1B2232'), array('alignment' => Jc::CENTER));
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $oPreserveText->getFontStyle());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oPreserveText->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $oPreserveText->getFontStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oPreserveText->getParagraphStyle());
     }
 }

--- a/tests/PhpWord/Element/RowTest.php
+++ b/tests/PhpWord/Element/RowTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Row
+ * Test class for Shareforce\PhpWord\Element\Row
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\Row
+ * @coversDefaultClass \Shareforce\PhpWord\Element\Row
  * @runTestsInSeparateProcesses
  */
 class RowTest extends \PHPUnit\Framework\TestCase
@@ -32,11 +32,11 @@ class RowTest extends \PHPUnit\Framework\TestCase
     {
         $oRow = new Row();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Row', $oRow);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Row', $oRow);
         $this->assertNull($oRow->getHeight());
         $this->assertInternalType('array', $oRow->getCells());
         $this->assertCount(0, $oRow->getCells());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Row', $oRow->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Row', $oRow->getStyle());
     }
 
     /**
@@ -48,7 +48,7 @@ class RowTest extends \PHPUnit\Framework\TestCase
         $oRow = new Row($iVal, array('borderBottomSize' => 18, 'borderBottomColor' => '0000FF', 'bgColor' => '66BBFF'));
 
         $this->assertEquals($iVal, $oRow->getHeight());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Row', $oRow->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Row', $oRow->getStyle());
     }
 
     /**
@@ -59,7 +59,7 @@ class RowTest extends \PHPUnit\Framework\TestCase
         $oRow = new Row();
         $element = $oRow->addCell();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Cell', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Cell', $element);
         $this->assertCount(1, $oRow->getCells());
     }
 }

--- a/tests/PhpWord/Element/SDTTest.php
+++ b/tests/PhpWord/Element/SDTTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\SDT
+ * Test class for Shareforce\PhpWord\Element\SDT
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\SDT
+ * @coversDefaultClass \Shareforce\PhpWord\Element\SDT
  */
 class SDTTest extends \PHPUnit\Framework\TestCase
 {
@@ -40,7 +40,7 @@ class SDTTest extends \PHPUnit\Framework\TestCase
         $object->setAlias($alias);
         $object->setTag($tag);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\SDT', $object);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\SDT', $object);
         $this->assertEquals($type, $object->getType());
         $this->assertEquals($types, $object->getListItems());
         $this->assertEquals($value, $object->getValue());

--- a/tests/PhpWord/Element/SectionTest.php
+++ b/tests/PhpWord/Element/SectionTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Section as SectionStyle;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Section as SectionStyle;
 
 /**
- * @covers \PhpOffice\PhpWord\Element\Section
- * @coversDefaultClass \PhpOffice\PhpWord\Element\Section
+ * @covers \Shareforce\PhpWord\Element\Section
+ * @coversDefaultClass \Shareforce\PhpWord\Element\Section
  * @runTestsInSeparateProcesses
  */
 class SectionTest extends \PHPUnit\Framework\TestCase
@@ -31,14 +31,14 @@ class SectionTest extends \PHPUnit\Framework\TestCase
     public function testConstructorWithDefaultStyle()
     {
         $section = new Section(0);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Section', $section->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Section', $section->getStyle());
     }
 
     public function testConstructorWithArrayStyle()
     {
         $section = new Section(0, array('orientation' => 'landscape'));
         $style = $section->getStyle();
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Section', $style);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Section', $style);
         $this->assertEquals('landscape', $style->getOrientation());
     }
 
@@ -102,14 +102,14 @@ class SectionTest extends \PHPUnit\Framework\TestCase
         );
         $elmCount = 0;
         foreach ($elementTypes as $elementType) {
-            $this->assertInstanceOf("PhpOffice\\PhpWord\\Element\\{$elementType}", $elementCollection[$elmCount]);
+            $this->assertInstanceOf("Shareforce\\PhpWord\\Element\\{$elementType}", $elementCollection[$elmCount]);
             $elmCount++;
         }
     }
 
     /**
      * @coversNothing
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidObjectException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidObjectException
      */
     public function testAddObjectException()
     {
@@ -131,7 +131,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
         $section->addTitle('Test', 1);
         $elementCollection = $section->getElements();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Title', $elementCollection[0]);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Title', $elementCollection[0]);
     }
 
     /**
@@ -146,7 +146,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
 
         foreach ($elements as $element) {
             $method = "add{$element}";
-            $this->assertInstanceOf("PhpOffice\\PhpWord\\Element\\{$element}", $object->$method());
+            $this->assertInstanceOf("Shareforce\\PhpWord\\Element\\{$element}", $object->$method());
         }
         $this->assertFalse($object->hasDifferentFirstPage());
     }
@@ -186,7 +186,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers \PhpOffice\PhpWord\Element\AbstractContainer::removeElement
+     * @covers \Shareforce\PhpWord\Element\AbstractContainer::removeElement
      */
     public function testRemoveElementByIndex()
     {
@@ -201,7 +201,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers \PhpOffice\PhpWord\Element\AbstractContainer::removeElement
+     * @covers \Shareforce\PhpWord\Element\AbstractContainer::removeElement
      */
     public function testRemoveElementByElement()
     {

--- a/tests/PhpWord/Element/TOCTest.php
+++ b/tests/PhpWord/Element/TOCTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\PhpWord;
+use Shareforce\PhpWord\PhpWord;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\TOC
+ * Test class for Shareforce\PhpWord\Element\TOC
  *
  * @runTestsInSeparateProcesses
  */
@@ -33,14 +33,14 @@ class TOCTest extends \PHPUnit\Framework\TestCase
     {
         $expected = array(
             'position' => 9062,
-            'leader'   => \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_DOT,
+            'leader'   => \Shareforce\PhpWord\Style\Tab::TAB_LEADER_DOT,
             'indent'   => 200,
         );
         $object = new TOC(array('size' => 11), array('position' => $expected['position']));
         $tocStyle = $object->getStyleTOC();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\TOC', $tocStyle);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $object->getStyleFont());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\TOC', $tocStyle);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $object->getStyleFont());
 
         foreach ($expected as $key => $value) {
             $method = "get{$key}";

--- a/tests/PhpWord/Element/TableTest.php
+++ b/tests/PhpWord/Element/TableTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Table
+ * Test class for Shareforce\PhpWord\Element\Table
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\Table
+ * @coversDefaultClass \Shareforce\PhpWord\Element\Table
  * @runTestsInSeparateProcesses
  */
 class TableTest extends \PHPUnit\Framework\TestCase
@@ -32,7 +32,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
     {
         $oTable = new Table();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Table', $oTable);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Table', $oTable);
         $this->assertNull($oTable->getStyle());
         $this->assertNull($oTable->getWidth());
         $this->assertEquals(array(), $oTable->getRows());
@@ -56,7 +56,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
     {
         $oTable = new Table(array('borderSize' => 6, 'borderColor' => '006699', 'cellMargin' => 80));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Table', $oTable->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Table', $oTable->getStyle());
     }
 
     /**
@@ -77,7 +77,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
     {
         $oTable = new Table();
         $element = $oTable->addRow();
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Row', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Row', $element);
         $this->assertCount(1, $oTable->getRows());
     }
 
@@ -89,7 +89,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $oTable = new Table();
         $oTable->addRow();
         $element = $oTable->addCell();
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Cell', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Cell', $element);
     }
 
     /**

--- a/tests/PhpWord/Element/TextBoxTest.php
+++ b/tests/PhpWord/Element/TextBoxTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\TextBox
+ * Test class for Shareforce\PhpWord\Element\TextBox
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\TextBox
+ * @coversDefaultClass \Shareforce\PhpWord\Element\TextBox
  * @runTestsInSeparateProcesses
  */
 class TextBoxTest extends \PHPUnit\Framework\TestCase
@@ -32,7 +32,7 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
     {
         $oTextBox = new TextBox();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextBox', $oTextBox);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextBox', $oTextBox);
         $this->assertNull($oTextBox->getStyle());
     }
 
@@ -53,11 +53,11 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
     {
         $oTextBox = new TextBox(
             array(
-                'width'       => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(4.5),
-                'height'      => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(17.5),
+                'width'       => \Shareforce\PhpWord\Shared\Converter::cmToPixel(4.5),
+                'height'      => \Shareforce\PhpWord\Shared\Converter::cmToPixel(17.5),
                 'positioning' => 'absolute',
-                'marginLeft'  => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(15.4),
-                'marginTop'   => \PhpOffice\PhpWord\Shared\Converter::cmToPixel(9.9),
+                'marginLeft'  => \Shareforce\PhpWord\Shared\Converter::cmToPixel(15.4),
+                'marginTop'   => \Shareforce\PhpWord\Shared\Converter::cmToPixel(9.9),
                 'stroke'      => 0,
                 'innerMargin' => 0,
                 'borderSize'  => 1,
@@ -65,6 +65,6 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\TextBox', $oTextBox->getStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\TextBox', $oTextBox->getStyle());
     }
 }

--- a/tests/PhpWord/Element/TextBreakTest.php
+++ b/tests/PhpWord/Element/TextBreakTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\TextBreak
+ * Test class for Shareforce\PhpWord\Element\TextBreak
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\TextBreak
+ * @coversDefaultClass \Shareforce\PhpWord\Element\TextBreak
  * @runTestsInSeparateProcesses
  */
 class TextBreakTest extends \PHPUnit\Framework\TestCase
@@ -58,8 +58,8 @@ class TextBreakTest extends \PHPUnit\Framework\TestCase
         $fStyle = array('size' => 12);
         $pStyle = array('spacing' => 240);
         $object = new TextBreak($fStyle, $pStyle);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $object->getFontStyle());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $object->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $object->getFontStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $object->getParagraphStyle());
     }
 
     /**

--- a/tests/PhpWord/Element/TextRunTest.php
+++ b/tests/PhpWord/Element/TextRunTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\Style\Paragraph;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\TextRun
+ * Test class for Shareforce\PhpWord\Element\TextRun
  *
  * @runTestsInSeparateProcesses
  */
@@ -35,9 +35,9 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
     {
         $oTextRun = new TextRun();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $oTextRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $oTextRun);
         $this->assertCount(0, $oTextRun->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oTextRun->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oTextRun->getParagraphStyle());
     }
 
     /**
@@ -47,7 +47,7 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
     {
         $oTextRun = new TextRun('pStyle');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $oTextRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $oTextRun);
         $this->assertCount(0, $oTextRun->getElements());
         $this->assertEquals('pStyle', $oTextRun->getParagraphStyle());
     }
@@ -59,9 +59,9 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
     {
         $oTextRun = new TextRun(array('spacing' => 100));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $oTextRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $oTextRun);
         $this->assertCount(0, $oTextRun->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oTextRun->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oTextRun->getParagraphStyle());
     }
 
     /**
@@ -73,9 +73,9 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $oParagraphStyle->setAlignment(Jc::BOTH);
         $oTextRun = new TextRun($oParagraphStyle);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $oTextRun);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $oTextRun);
         $this->assertCount(0, $oTextRun->getElements());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oTextRun->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oTextRun->getParagraphStyle());
         $this->assertEquals(Jc::BOTH, $oTextRun->getParagraphStyle()->getAlignment());
     }
 
@@ -87,7 +87,7 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $oTextRun = new TextRun();
         $element = $oTextRun->addText('text');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertCount(1, $oTextRun->getElements());
         $this->assertEquals('text', $element->getText());
     }
@@ -100,7 +100,7 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $oTextRun = new TextRun();
         $element = $oTextRun->addText(utf8_decode('ééé'));
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $element);
         $this->assertCount(1, $oTextRun->getElements());
         $this->assertEquals('ééé', $element->getText());
     }
@@ -113,7 +113,7 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $oTextRun = new TextRun();
         $element = $oTextRun->addLink('https://github.com/PHPOffice/PHPWord');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $element);
         $this->assertCount(1, $oTextRun->getElements());
         $this->assertEquals('https://github.com/PHPOffice/PHPWord', $element->getSource());
     }
@@ -126,7 +126,7 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $oTextRun = new TextRun();
         $element = $oTextRun->addLink('https://github.com/PHPOffice/PHPWord', 'PHPWord on GitHub');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Link', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Link', $element);
         $this->assertCount(1, $oTextRun->getElements());
         $this->assertEquals('https://github.com/PHPOffice/PHPWord', $element->getSource());
         $this->assertEquals('PHPWord on GitHub', $element->getText());
@@ -153,7 +153,7 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $oTextRun = new TextRun();
         $element = $oTextRun->addImage($src);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Image', $element);
         $this->assertCount(1, $oTextRun->getElements());
     }
 
@@ -166,7 +166,7 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $oTextRun->setPhpWord(new PhpWord());
         $element = $oTextRun->addFootnote();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Footnote', $element);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Footnote', $element);
         $this->assertCount(1, $oTextRun->getElements());
     }
 
@@ -179,6 +179,6 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('paragraphStyle', $oText->getParagraphStyle());
 
         $oText->setParagraphStyle(array('alignment' => Jc::CENTER, 'spaceAfter' => 100));
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
     }
 }

--- a/tests/PhpWord/Element/TextTest.php
+++ b/tests/PhpWord/Element/TextTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\Style\Font;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\Style\Font;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Text
+ * Test class for Shareforce\PhpWord\Element\Text
  *
  * @runTestsInSeparateProcesses
  */
@@ -34,10 +34,10 @@ class TextTest extends \PHPUnit\Framework\TestCase
     {
         $oText = new Text();
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Text', $oText);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Text', $oText);
         $this->assertNull($oText->getText());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $oText->getFontStyle());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $oText->getFontStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
     }
 
     /**
@@ -59,7 +59,7 @@ class TextTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('fontStyle', $oText->getFontStyle());
 
         $oText->setFontStyle(array('bold' => true, 'italic' => true, 'size' => 16));
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', $oText->getFontStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', $oText->getFontStyle());
     }
 
     /**
@@ -81,6 +81,6 @@ class TextTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('paragraphStyle', $oText->getParagraphStyle());
 
         $oText->setParagraphStyle(array('alignment' => Jc::CENTER, 'spaceAfter' => 100));
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
     }
 }

--- a/tests/PhpWord/Element/TitleTest.php
+++ b/tests/PhpWord/Element/TitleTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\Title
+ * Test class for Shareforce\PhpWord\Element\Title
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\Title
+ * @coversDefaultClass \Shareforce\PhpWord\Element\Title
  * @runTestsInSeparateProcesses
  */
 class TitleTest extends \PHPUnit\Framework\TestCase
@@ -32,7 +32,7 @@ class TitleTest extends \PHPUnit\Framework\TestCase
     {
         $oTitle = new Title('text');
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Title', $oTitle);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\Title', $oTitle);
         $this->assertEquals('text', $oTitle->getText());
     }
 
@@ -55,7 +55,7 @@ class TitleTest extends \PHPUnit\Framework\TestCase
         $oTextRun->addText('text');
         $oTitle = new Title($oTextRun);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $oTitle->getText());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TextRun', $oTitle->getText());
     }
 
     /**

--- a/tests/PhpWord/Element/TrackChangeTest.php
+++ b/tests/PhpWord/Element/TrackChangeTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Element;
+namespace Shareforce\PhpWord\Element;
 
 /**
- * Test class for PhpOffice\PhpWord\Element\TrackChange
+ * Test class for Shareforce\PhpWord\Element\TrackChange
  *
  * @runTestsInSeparateProcesses
  */
@@ -36,7 +36,7 @@ class TrackChangeTest extends \PHPUnit\Framework\TestCase
         $oText = new Text('dummy text');
         $oText->setTrackChange($oTrackChange);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TrackChange', $oTrackChange);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TrackChange', $oTrackChange);
         $this->assertEquals($author, $oTrackChange->getAuthor());
         $this->assertEquals($date, $oTrackChange->getDate());
         $this->assertEquals(TrackChange::INSERTED, $oTrackChange->getChangeType());
@@ -54,7 +54,7 @@ class TrackChangeTest extends \PHPUnit\Framework\TestCase
         $oText = new Text('dummy text');
         $oText->setTrackChange($oTrackChange);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TrackChange', $oTrackChange);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Element\\TrackChange', $oTrackChange);
         $this->assertEquals($author, $oTrackChange->getAuthor());
         $this->assertEquals($date, null);
         $this->assertEquals(TrackChange::INSERTED, $oTrackChange->getChangeType());

--- a/tests/PhpWord/Escaper/RtfEscaper2Test.php
+++ b/tests/PhpWord/Escaper/RtfEscaper2Test.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Escaper;
+namespace Shareforce\PhpWord\Escaper;
 
 /**
- * Test class for PhpOffice\PhpWord\Escaper\RTF
+ * Test class for Shareforce\PhpWord\Escaper\RTF
  */
 class RtfEscaper2Test extends \PHPUnit\Framework\TestCase
 {
@@ -27,10 +27,10 @@ class RtfEscaper2Test extends \PHPUnit\Framework\TestCase
 
     public function escapestring($str)
     {
-        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
-        $parentWriter = new \PhpOffice\PhpWord\Writer\RTF();
-        $element = new \PhpOffice\PhpWord\Element\Text($str);
-        $txt = new \PhpOffice\PhpWord\Writer\RTF\Element\Text($parentWriter, $element);
+        \Shareforce\PhpWord\Settings::setOutputEscapingEnabled(true);
+        $parentWriter = new \Shareforce\PhpWord\Writer\RTF();
+        $element = new \Shareforce\PhpWord\Element\Text($str);
+        $txt = new \Shareforce\PhpWord\Writer\RTF\Element\Text($parentWriter, $element);
         $txt2 = trim($txt->write());
 
         return $txt2;

--- a/tests/PhpWord/Exception/CopyFileExceptionTest.php
+++ b/tests/PhpWord/Exception/CopyFileExceptionTest.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
- * @covers \PhpOffice\PhpWord\Exception\CopyFileException
- * @coversDefaultClass \PhpOffice\PhpWord\Exception\CopyFileException
+ * @covers \Shareforce\PhpWord\Exception\CopyFileException
+ * @coversDefaultClass \Shareforce\PhpWord\Exception\CopyFileException
  */
 class CopyFileExceptionTest extends \PHPUnit\Framework\TestCase
 {
@@ -27,7 +27,7 @@ class CopyFileExceptionTest extends \PHPUnit\Framework\TestCase
      * CopyFileException can be thrown.
      *
      * @covers            ::__construct()
-     * @expectedException \PhpOffice\PhpWord\Exception\CopyFileException
+     * @expectedException \Shareforce\PhpWord\Exception\CopyFileException
      * @test
      */
     public function testCopyFileExceptionCanBeThrown()

--- a/tests/PhpWord/Exception/CreateTemporaryFileExceptionTest.php
+++ b/tests/PhpWord/Exception/CreateTemporaryFileExceptionTest.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
- * @covers \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
- * @coversDefaultClass \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
+ * @covers \Shareforce\PhpWord\Exception\CreateTemporaryFileException
+ * @coversDefaultClass \Shareforce\PhpWord\Exception\CreateTemporaryFileException
  */
 class CreateTemporaryFileExceptionTest extends \PHPUnit\Framework\TestCase
 {
@@ -27,7 +27,7 @@ class CreateTemporaryFileExceptionTest extends \PHPUnit\Framework\TestCase
      * CreateTemporaryFileException can be thrown.
      *
      * @covers            ::__construct()
-     * @expectedException \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
+     * @expectedException \Shareforce\PhpWord\Exception\CreateTemporaryFileException
      * @test
      */
     public function testCreateTemporaryFileExceptionCanBeThrown()

--- a/tests/PhpWord/Exception/ExceptionTest.php
+++ b/tests/PhpWord/Exception/ExceptionTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
- * Test class for PhpOffice\PhpWord\Exception\Exception
+ * Test class for Shareforce\PhpWord\Exception\Exception
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Exception\Exception
+ * @coversDefaultClass \Shareforce\PhpWord\Exception\Exception
  * @runTestsInSeparateProcesses
  */
 class ExceptionTest extends \PHPUnit\Framework\TestCase
@@ -28,8 +28,8 @@ class ExceptionTest extends \PHPUnit\Framework\TestCase
     /**
      * Throw new exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
-     * @covers            \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
+     * @covers            \Shareforce\PhpWord\Exception\Exception
      */
     public function testThrowException()
     {

--- a/tests/PhpWord/Exception/InvalidImageExceptionTest.php
+++ b/tests/PhpWord/Exception/InvalidImageExceptionTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
- * Test class for PhpOffice\PhpWord\Exception\InvalidImageException
+ * Test class for Shareforce\PhpWord\Exception\InvalidImageException
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Exception\InvalidImageException
+ * @coversDefaultClass \Shareforce\PhpWord\Exception\InvalidImageException
  * @runTestsInSeparateProcesses
  */
 class InvalidImageExceptionTest extends \PHPUnit\Framework\TestCase
@@ -28,8 +28,8 @@ class InvalidImageExceptionTest extends \PHPUnit\Framework\TestCase
     /**
      * Throw new exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidImageException
-     * @covers            \PhpOffice\PhpWord\Exception\InvalidImageException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidImageException
+     * @covers            \Shareforce\PhpWord\Exception\InvalidImageException
      */
     public function testThrowException()
     {

--- a/tests/PhpWord/Exception/InvalidStyleExceptionTest.php
+++ b/tests/PhpWord/Exception/InvalidStyleExceptionTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
- * Test class for PhpOffice\PhpWord\Exception\InvalidStyleException
+ * Test class for Shareforce\PhpWord\Exception\InvalidStyleException
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Exception\InvalidStyleException
+ * @coversDefaultClass \Shareforce\PhpWord\Exception\InvalidStyleException
  * @runTestsInSeparateProcesses
  */
 class InvalidStyleExceptionTest extends \PHPUnit\Framework\TestCase
@@ -28,8 +28,8 @@ class InvalidStyleExceptionTest extends \PHPUnit\Framework\TestCase
     /**
      * Throw new exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidStyleException
-     * @covers            \PhpOffice\PhpWord\Exception\InvalidStyleException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidStyleException
+     * @covers            \Shareforce\PhpWord\Exception\InvalidStyleException
      */
     public function testThrowException()
     {

--- a/tests/PhpWord/Exception/UnsupportedImageTypeExceptionTest.php
+++ b/tests/PhpWord/Exception/UnsupportedImageTypeExceptionTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Exception;
+namespace Shareforce\PhpWord\Exception;
 
 /**
- * Test class for PhpOffice\PhpWord\Exception\UnsupportedImageTypeExceptionTest
+ * Test class for Shareforce\PhpWord\Exception\UnsupportedImageTypeExceptionTest
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Exception\UnsupportedImageTypeExceptionTest
+ * @coversDefaultClass \Shareforce\PhpWord\Exception\UnsupportedImageTypeExceptionTest
  * @runTestsInSeparateProcesses
  */
 class UnsupportedImageTypeExceptionTest extends \PHPUnit\Framework\TestCase
@@ -28,8 +28,8 @@ class UnsupportedImageTypeExceptionTest extends \PHPUnit\Framework\TestCase
     /**
      * Throw new exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\UnsupportedImageTypeException
-     * @covers            \PhpOffice\PhpWord\Exception\UnsupportedImageTypeException
+     * @expectedException \Shareforce\PhpWord\Exception\UnsupportedImageTypeException
+     * @covers            \Shareforce\PhpWord\Exception\UnsupportedImageTypeException
      */
     public function testThrowException()
     {

--- a/tests/PhpWord/IOFactoryTest.php
+++ b/tests/PhpWord/IOFactoryTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 /**
- * Test class for PhpOffice\PhpWord\IOFactory
+ * Test class for Shareforce\PhpWord\IOFactory
  *
  * @runTestsInSeparateProcesses
  */
@@ -30,7 +30,7 @@ class IOFactoryTest extends \PHPUnit\Framework\TestCase
     public function testExistingWriterCanBeCreated()
     {
         $this->assertInstanceOf(
-            'PhpOffice\\PhpWord\\Writer\\Word2007',
+            'Shareforce\\PhpWord\\Writer\\Word2007',
             IOFactory::createWriter(new PhpWord(), 'Word2007')
         );
     }
@@ -38,7 +38,7 @@ class IOFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Create non-existing writer
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      */
     public function testNonexistentWriterCanNotBeCreated()
     {
@@ -51,7 +51,7 @@ class IOFactoryTest extends \PHPUnit\Framework\TestCase
     public function testExistingReaderCanBeCreated()
     {
         $this->assertInstanceOf(
-            'PhpOffice\\PhpWord\\Reader\\Word2007',
+            'Shareforce\\PhpWord\\Reader\\Word2007',
             IOFactory::createReader('Word2007')
         );
     }
@@ -59,7 +59,7 @@ class IOFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Create non-existing reader
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      */
     public function testNonexistentReaderCanNotBeCreated()
     {
@@ -73,7 +73,7 @@ class IOFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $file = __DIR__ . '/_files/templates/blank.docx';
         $this->assertInstanceOf(
-            'PhpOffice\\PhpWord\\PhpWord',
+            'Shareforce\\PhpWord\\PhpWord',
             IOFactory::load($file)
         );
     }

--- a/tests/PhpWord/MediaTest.php
+++ b/tests/PhpWord/MediaTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Element\Image;
+use Shareforce\PhpWord\Element\Image;
 
 /**
- * Test class for PhpOffice\PhpWord\Media
+ * Test class for Shareforce\PhpWord\Media
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Metadata/DocInfoTest.php
+++ b/tests/PhpWord/Metadata/DocInfoTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Metadata;
+namespace Shareforce\PhpWord\Metadata;
 
 /**
- * Test class for PhpOffice\PhpWord\Metadata\DocInfo
+ * Test class for Shareforce\PhpWord\Metadata\DocInfo
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Metadata/SettingsTest.php
+++ b/tests/PhpWord/Metadata/SettingsTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Metadata;
+namespace Shareforce\PhpWord\Metadata;
 
-use PhpOffice\PhpWord\ComplexType\ProofState;
-use PhpOffice\PhpWord\SimpleType\Zoom;
+use Shareforce\PhpWord\ComplexType\ProofState;
+use Shareforce\PhpWord\SimpleType\Zoom;
 
 /**
- * Test class for PhpOffice\PhpWord\Metadata\Settings
+ * Test class for Shareforce\PhpWord\Metadata\Settings
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/PhpWordTest.php
+++ b/tests/PhpWord/PhpWordTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Metadata\DocInfo;
+use Shareforce\PhpWord\Metadata\DocInfo;
 
 /**
- * Test class for PhpOffice\PhpWord\PhpWord
+ * Test class for Shareforce\PhpWord\PhpWord
  *
  * @runTestsInSeparateProcesses
  */
@@ -78,7 +78,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
     {
         $phpWord = new PhpWord();
         $phpWord->setDefaultParagraphStyle(array());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', Style::getStyle('Normal'));
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', Style::getStyle('Normal'));
     }
 
     /**
@@ -97,7 +97,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
             $method = "add{$key}Style";
             $styleId = "{$key} Style";
             $phpWord->$method($styleId, array());
-            $this->assertInstanceOf("PhpOffice\\PhpWord\\Style\\{$value}", Style::getStyle($styleId));
+            $this->assertInstanceOf("Shareforce\\PhpWord\\Style\\{$value}", Style::getStyle($styleId));
         }
     }
 
@@ -110,7 +110,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
         $titleLevel = 1;
         $titleName = "Heading_{$titleLevel}";
         $phpWord->addTitleStyle($titleLevel, array());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', Style::getStyle($titleName));
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', Style::getStyle($titleName));
     }
 
     /**
@@ -124,7 +124,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
 
         $phpWord = new PhpWord();
         $this->assertInstanceOf(
-            'PhpOffice\\PhpWord\\TemplateProcessor',
+            'Shareforce\\PhpWord\\TemplateProcessor',
             $phpWord->loadTemplate($templateFqfn)
         );
     }
@@ -134,7 +134,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
      *
      * @deprecated 0.12.0
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      */
     public function testLoadTemplateException()
     {
@@ -173,7 +173,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers \PhpOffice\PhpWord\PhpWord::getSection
+     * @covers \Shareforce\PhpWord\PhpWord::getSection
      */
     public function testGetNotExistingSection()
     {
@@ -184,7 +184,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers \PhpOffice\PhpWord\PhpWord::getSection
+     * @covers \Shareforce\PhpWord\PhpWord::getSection
      */
     public function testGetSection()
     {
@@ -196,7 +196,7 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers \PhpOffice\PhpWord\PhpWord::sortSections
+     * @covers \Shareforce\PhpWord\PhpWord::sortSections
      */
     public function testSortSections()
     {
@@ -227,11 +227,11 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers \PhpOffice\PhpWord\PhpWord::getSettings
+     * @covers \Shareforce\PhpWord\PhpWord::getSettings
      */
     public function testGetSettings()
     {
         $phpWord = new PhpWord();
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Metadata\\Settings', $phpWord->getSettings());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Metadata\\Settings', $phpWord->getSettings());
     }
 }

--- a/tests/PhpWord/Reader/HTMLTest.php
+++ b/tests/PhpWord/Reader/HTMLTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\IOFactory;
+use Shareforce\PhpWord\IOFactory;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\HTML
+ * Test class for Shareforce\PhpWord\Reader\HTML
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Reader\HTML
+ * @coversDefaultClass \Shareforce\PhpWord\Reader\HTML
  * @runTestsInSeparateProcesses
  */
 class HTMLTest extends \PHPUnit\Framework\TestCase
@@ -34,7 +34,7 @@ class HTMLTest extends \PHPUnit\Framework\TestCase
     {
         $filename = __DIR__ . '/../_files/documents/reader.html';
         $phpWord = IOFactory::load($filename, 'HTML');
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $phpWord);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $phpWord);
     }
 
     /**

--- a/tests/PhpWord/Reader/MsDocTest.php
+++ b/tests/PhpWord/Reader/MsDocTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\IOFactory;
+use Shareforce\PhpWord\IOFactory;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\MsDoc
+ * Test class for Shareforce\PhpWord\Reader\MsDoc
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Reader\MsDoc
+ * @coversDefaultClass \Shareforce\PhpWord\Reader\MsDoc
  * @runTestsInSeparateProcesses
  */
 class MsDocTest extends \PHPUnit\Framework\TestCase
@@ -54,7 +54,7 @@ class MsDocTest extends \PHPUnit\Framework\TestCase
     {
         $filename = __DIR__ . '/../_files/documents/reader.doc';
         $phpWord = IOFactory::load($filename, 'MsDoc');
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $phpWord);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $phpWord);
     }
 
     /**

--- a/tests/PhpWord/Reader/ODTextTest.php
+++ b/tests/PhpWord/Reader/ODTextTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\IOFactory;
+use Shareforce\PhpWord\IOFactory;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\ODText
+ * Test class for Shareforce\PhpWord\Reader\ODText
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Reader\ODText
+ * @coversDefaultClass \Shareforce\PhpWord\Reader\ODText
  * @runTestsInSeparateProcesses
  */
 class ODTextTest extends \PHPUnit\Framework\TestCase
@@ -34,6 +34,6 @@ class ODTextTest extends \PHPUnit\Framework\TestCase
     {
         $filename = __DIR__ . '/../_files/documents/reader.odt';
         $phpWord = IOFactory::load($filename, 'ODText');
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $phpWord);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $phpWord);
     }
 }

--- a/tests/PhpWord/Reader/RTFTest.php
+++ b/tests/PhpWord/Reader/RTFTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\IOFactory;
+use Shareforce\PhpWord\IOFactory;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\RTF
+ * Test class for Shareforce\PhpWord\Reader\RTF
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Reader\RTF
+ * @coversDefaultClass \Shareforce\PhpWord\Reader\RTF
  * @runTestsInSeparateProcesses
  */
 class RTFTest extends \PHPUnit\Framework\TestCase
@@ -34,7 +34,7 @@ class RTFTest extends \PHPUnit\Framework\TestCase
     {
         $filename = __DIR__ . '/../_files/documents/reader.rtf';
         $phpWord = IOFactory::load($filename, 'RTF');
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $phpWord);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $phpWord);
     }
 
     /**

--- a/tests/PhpWord/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWord/Reader/Word2007/ElementTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\AbstractTestReader;
-use PhpOffice\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\AbstractTestReader;
+use Shareforce\PhpWord\Element\TrackChange;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\Word2007\Element subnamespace
+ * Test class for Shareforce\PhpWord\Reader\Word2007\Element subnamespace
  */
 class ElementTest extends AbstractTestReader
 {
@@ -59,8 +59,8 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $elements[0]->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $elements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $elements[0]->getElement(0));
         $text = $elements[0];
         $this->assertEquals('Test node value', trim($text->getElement(0)->getText()));
     }
@@ -80,11 +80,11 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
-        /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $elements[0]);
+        /** @var \Shareforce\PhpWord\Element\TextRun $textRun */
         $textRun = $elements[0];
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextBreak', $textRun->getElement(0));
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $textRun->getElement(1));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextBreak', $textRun->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $textRun->getElement(1));
         $this->assertEquals('test string', $textRun->getElement(1)->getText());
     }
 
@@ -104,10 +104,10 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
-        /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $elements[0]);
+        /** @var \Shareforce\PhpWord\Element\TextRun $textRun */
         $textRun = $elements[0];
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $textRun->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $textRun->getElement(0));
         $this->assertEquals('test string', $textRun->getElement(0)->getText());
     }
 
@@ -141,11 +141,11 @@ class ElementTest extends AbstractTestReader
 
         $sections = $phpWord->getSection(0);
         $this->assertNull($sections->getElement(999));
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\ListItemRun', $sections->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\ListItemRun', $sections->getElement(0));
         $this->assertEquals(0, $sections->getElement(0)->getDepth());
 
         $listElements = $sections->getElement(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $listElements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $listElements[0]);
         $this->assertEquals('Two', $listElements[0]->getText());
         $this->assertEquals(' with ', $listElements[1]->getText());
         $this->assertEquals('bold', $listElements[2]->getText());
@@ -176,21 +176,21 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
-        /** @var \PhpOffice\PhpWord\Element\TextRun $elements */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $elements[0]);
+        /** @var \Shareforce\PhpWord\Element\TextRun $elements */
         $textRun = $elements[0];
 
         $this->assertEquals('One ', $textRun->getElement(0)->getText());
 
         $this->assertEquals('two', $textRun->getElement(1)->getText());
         $this->assertNotNull($textRun->getElement(1)->getTrackChange());
-        /** @var \PhpOffice\PhpWord\Element\TrackChange $trackChange */
+        /** @var \Shareforce\PhpWord\Element\TrackChange $trackChange */
         $trackChange = $textRun->getElement(1)->getTrackChange();
         $this->assertEquals(TrackChange::DELETED, $trackChange->getChangeType());
 
         $this->assertEquals('three', $textRun->getElement(2)->getText());
         $this->assertNotNull($textRun->getElement(2)->getTrackChange());
-        /** @var \PhpOffice\PhpWord\Element\TrackChange $trackChange */
+        /** @var \Shareforce\PhpWord\Element\TrackChange $trackChange */
         $trackChange = $textRun->getElement(2)->getTrackChange();
         $this->assertEquals(TrackChange::INSERTED, $trackChange->getChangeType());
     }
@@ -211,14 +211,14 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
-        /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $elements[0]);
+        /** @var \Shareforce\PhpWord\Element\TextRun $textRun */
         $textRun = $elements[0];
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $textRun->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $textRun->getElement(0));
         $this->assertEquals('One', $textRun->getElement(0)->getText());
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $textRun->getElement(1));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $textRun->getElement(1));
         $this->assertEquals("\t", $textRun->getElement(1)->getText());
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $textRun->getElement(2));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $textRun->getElement(2));
         $this->assertEquals('Two', $textRun->getElement(2)->getText());
     }
 
@@ -264,17 +264,17 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml, 'styles' => $stylesXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Title', $elements[0]);
-        /** @var \PhpOffice\PhpWord\Element\Title $title */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Title', $elements[0]);
+        /** @var \Shareforce\PhpWord\Element\Title $title */
         $title = $elements[0];
         $this->assertEquals('Title', $title->getStyle());
         $this->assertEquals('This is a non formatted title', $title->getText());
 
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Title', $elements[1]);
-        /** @var \PhpOffice\PhpWord\Element\Title $formattedTitle */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Title', $elements[1]);
+        /** @var \Shareforce\PhpWord\Element\Title $formattedTitle */
         $formattedTitle = $elements[1];
         $this->assertEquals('Title', $formattedTitle->getStyle());
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $formattedTitle->getText());
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $formattedTitle->getText());
     }
 
     /**
@@ -310,6 +310,6 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $elements[0]);
     }
 }

--- a/tests/PhpWord/Reader/Word2007/PartTest.php
+++ b/tests/PhpWord/Reader/Word2007/PartTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\AbstractTestReader;
+use Shareforce\PhpWord\AbstractTestReader;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\Word2007 subnamespace
+ * Test class for Shareforce\PhpWord\Reader\Word2007 subnamespace
  */
 class PartTest extends AbstractTestReader
 {
@@ -116,48 +116,48 @@ class PartTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml, 'footnotes' => $footnotesXml, 'endnotes' => $endnotesXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
-        /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $elements[0]);
+        /** @var \Shareforce\PhpWord\Element\TextRun $textRun */
         $textRun = $elements[0];
 
         //test the text in the first paragraph
-        /** @var \PhpOffice\PhpWord\Element\Text $text */
+        /** @var \Shareforce\PhpWord\Element\Text $text */
         $text = $elements[0]->getElement(0);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $text);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $text);
         $this->assertEquals('This is a test', $text->getText());
 
         //test the presence of the footnote in the document.xml
-        /** @var \PhpOffice\PhpWord\Element\Footnote $footnote */
+        /** @var \Shareforce\PhpWord\Element\Footnote $footnote */
         $documentFootnote = $textRun->getElement(1);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Footnote', $documentFootnote);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Footnote', $documentFootnote);
         $this->assertEquals(1, $documentFootnote->getRelationId());
 
         //test the presence of the footnote in the footnote.xml
-        /** @var \PhpOffice\PhpWord\Element\Footnote $footnote */
+        /** @var \Shareforce\PhpWord\Element\Footnote $footnote */
         $footnote = $phpWord->getFootnotes()->getItem(1);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Footnote', $footnote);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $footnote->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Footnote', $footnote);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $footnote->getElement(0));
         $this->assertEquals('footnote text', $footnote->getElement(0)->getText());
         $this->assertEquals(1, $footnote->getRelationId());
 
         //test the text in the second paragraph
-        /** @var \PhpOffice\PhpWord\Element\Text $text */
+        /** @var \Shareforce\PhpWord\Element\Text $text */
         $text = $elements[1]->getElement(0);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $text);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $text);
         $this->assertEquals('And another one', $text->getText());
 
         //test the presence of the endnote in the document.xml
-        /** @var \PhpOffice\PhpWord\Element\Endnote $endnote */
+        /** @var \Shareforce\PhpWord\Element\Endnote $endnote */
         $documentEndnote = $elements[1]->getElement(1);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Endnote', $documentEndnote);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Endnote', $documentEndnote);
         $this->assertEquals(2, $documentEndnote->getRelationId());
 
         //test the presence of the endnote in the endnote.xml
-        /** @var \PhpOffice\PhpWord\Element\Endnote $endnote */
+        /** @var \Shareforce\PhpWord\Element\Endnote $endnote */
         $endnote = $phpWord->getEndnotes()->getItem(1);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Endnote', $endnote);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Endnote', $endnote);
         $this->assertEquals(2, $endnote->getRelationId());
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $endnote->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $endnote->getElement(0));
         $this->assertEquals('This is an endnote', $endnote->getElement(0)->getText());
     }
 
@@ -211,25 +211,25 @@ class PartTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml, 'styles' => $stylesXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Title', $elements[0]);
-        /** @var \PhpOffice\PhpWord\Element\Title $title */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Title', $elements[0]);
+        /** @var \Shareforce\PhpWord\Element\Title $title */
         $title = $elements[0];
         $this->assertEquals('Heading1', $title->getStyle());
 
-        /** @var \PhpOffice\PhpWord\Element\Text $text */
+        /** @var \Shareforce\PhpWord\Element\Text $text */
         $text = $title->getText()->getElement(0);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $text);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $text);
         $this->assertEquals('This is a bold ', $text->getText());
 
-        /** @var \PhpOffice\PhpWord\Element\Text $text */
+        /** @var \Shareforce\PhpWord\Element\Text $text */
         $text = $title->getText()->getElement(1);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $text);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $text);
         $this->assertEquals('heading', $text->getText());
         $this->assertFalse($text->getFontStyle()->isBold());
 
-        /** @var \PhpOffice\PhpWord\Element\Text $text */
+        /** @var \Shareforce\PhpWord\Element\Text $text */
         $text = $title->getText()->getElement(2);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $text);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $text);
         $this->assertEquals(' but with parts not in bold', $text->getText());
     }
 }

--- a/tests/PhpWord/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWord/Reader/Word2007/StyleTest.php
@@ -15,17 +15,17 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader\Word2007;
+namespace Shareforce\PhpWord\Reader\Word2007;
 
-use PhpOffice\PhpWord\AbstractTestReader;
-use PhpOffice\PhpWord\SimpleType\TblWidth;
-use PhpOffice\PhpWord\SimpleType\VerticalJc;
-use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\Table;
-use PhpOffice\PhpWord\Style\TablePosition;
+use Shareforce\PhpWord\AbstractTestReader;
+use Shareforce\PhpWord\SimpleType\TblWidth;
+use Shareforce\PhpWord\SimpleType\VerticalJc;
+use Shareforce\PhpWord\Style;
+use Shareforce\PhpWord\Style\Table;
+use Shareforce\PhpWord\Style\TablePosition;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\Word2007\Styles
+ * Test class for Shareforce\PhpWord\Reader\Word2007\Styles
  */
 class StyleTest extends AbstractTestReader
 {
@@ -43,8 +43,8 @@ class StyleTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Table', $elements[0]->getStyle());
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Table', $elements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Table', $elements[0]->getStyle());
         $this->assertEquals(Table::LAYOUT_FIXED, $elements[0]->getStyle()->getLayout());
     }
 
@@ -62,9 +62,9 @@ class StyleTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Table', $elements[0]->getStyle());
-        /** @var \PhpOffice\PhpWord\Style\Table $tableStyle */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Table', $elements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Table', $elements[0]->getStyle());
+        /** @var \Shareforce\PhpWord\Style\Table $tableStyle */
         $tableStyle = $elements[0]->getStyle();
         $this->assertEquals(TblWidth::AUTO, $tableStyle->getUnit());
         $this->assertEquals(10.5, $tableStyle->getCellSpacing());
@@ -84,11 +84,11 @@ class StyleTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Table', $elements[0]->getStyle());
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Table', $elements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Table', $elements[0]->getStyle());
         $this->assertNotNull($elements[0]->getStyle()->getPosition());
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\TablePosition', $elements[0]->getStyle()->getPosition());
-        /** @var \PhpOffice\PhpWord\Style\TablePosition $tableStyle */
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\TablePosition', $elements[0]->getStyle()->getPosition());
+        /** @var \Shareforce\PhpWord\Style\TablePosition $tableStyle */
         $tableStyle = $elements[0]->getStyle()->getPosition();
         $this->assertEquals(10, $tableStyle->getLeftFromText());
         $this->assertEquals(20, $tableStyle->getRightFromText());
@@ -119,12 +119,12 @@ class StyleTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        /** @var \PhpOffice\PhpWord\Element\TextRun $elements */
+        /** @var \Shareforce\PhpWord\Element\TextRun $elements */
         $textRun = $elements[0];
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $textRun);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $textRun->getElement(0));
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Font', $textRun->getElement(0)->getFontStyle());
-        /** @var \PhpOffice\PhpWord\Style\Font $fontStyle */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $textRun);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $textRun->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Font', $textRun->getElement(0)->getFontStyle());
+        /** @var \Shareforce\PhpWord\Style\Font $fontStyle */
         $fontStyle = $textRun->getElement(0)->getFontStyle();
         $this->assertEquals(15, $fontStyle->getPosition());
     }
@@ -140,9 +140,9 @@ class StyleTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Table', $elements[0]->getStyle());
-        /** @var \PhpOffice\PhpWord\Style\Table $tableStyle */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Table', $elements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Table', $elements[0]->getStyle());
+        /** @var \Shareforce\PhpWord\Style\Table $tableStyle */
         $tableStyle = $elements[0]->getStyle();
         $this->assertSame(TblWidth::TWIP, $tableStyle->getIndent()->getType());
         $this->assertSame(2160, $tableStyle->getIndent()->getValue());
@@ -159,9 +159,9 @@ class StyleTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Table', $elements[0]->getStyle());
-        /** @var \PhpOffice\PhpWord\Style\Table $tableStyle */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Table', $elements[0]);
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Table', $elements[0]->getStyle());
+        /** @var \Shareforce\PhpWord\Style\Table $tableStyle */
         $tableStyle = $elements[0]->getStyle();
         $this->assertTrue($tableStyle->isBidiVisual());
     }
@@ -180,12 +180,12 @@ class StyleTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
 
         $elements = $phpWord->getSection(0)->getElements();
-        /** @var \PhpOffice\PhpWord\Element\TextRun $elements */
+        /** @var \Shareforce\PhpWord\Element\TextRun $elements */
         $textRun = $elements[0];
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $textRun);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $textRun->getElement(0));
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Font', $textRun->getElement(0)->getFontStyle());
-        /** @var \PhpOffice\PhpWord\Style\Font $fontStyle */
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\TextRun', $textRun);
+        $this->assertInstanceOf('Shareforce\PhpWord\Element\Text', $textRun->getElement(0));
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Font', $textRun->getElement(0)->getFontStyle());
+        /** @var \Shareforce\PhpWord\Style\Font $fontStyle */
         $fontStyle = $textRun->getElement(0)->getFontStyle();
         $this->assertTrue($fontStyle->isHidden());
     }
@@ -212,7 +212,7 @@ class StyleTest extends AbstractTestReader
         $name = 'Heading_1';
 
         $this->getDocumentFromString(array('styles' => $documentXml));
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', Style::getStyle($name));
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Font', Style::getStyle($name));
     }
 
     public function testPageVerticalAlign()

--- a/tests/PhpWord/Reader/Word2007Test.php
+++ b/tests/PhpWord/Reader/Word2007Test.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Reader;
+namespace Shareforce\PhpWord\Reader;
 
-use PhpOffice\PhpWord\IOFactory;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\IOFactory;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Reader\Word2007
+ * Test class for Shareforce\PhpWord\Reader\Word2007
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Reader\Word2007
+ * @coversDefaultClass \Shareforce\PhpWord\Reader\Word2007
  * @runTestsInSeparateProcesses
  */
 class Word2007Test extends \PHPUnit\Framework\TestCase
@@ -56,7 +56,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $filename = __DIR__ . '/../_files/documents/reader.docx';
         $phpWord = IOFactory::load($filename);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $phpWord);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $phpWord);
         $this->assertTrue($phpWord->getSettings()->hasDoNotTrackMoves());
         $this->assertFalse($phpWord->getSettings()->hasDoNotTrackFormatting());
         $this->assertEquals(100, $phpWord->getSettings()->getZoom());
@@ -73,7 +73,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $filename = __DIR__ . '/../_files/documents/reader-2011.docx';
         $phpWord = IOFactory::load($filename);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $phpWord);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $phpWord);
 
         $doc = TestHelperDOCX::getDocument($phpWord);
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p[3]/w:r/w:pict/v:shape/v:imagedata'));

--- a/tests/PhpWord/SettingsTest.php
+++ b/tests/PhpWord/SettingsTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 /**
- * Test class for PhpOffice\PhpWord\Settings
+ * Test class for Shareforce\PhpWord\Settings
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Settings
+ * @coversDefaultClass \Shareforce\PhpWord\Settings
  * @runTestsInSeparateProcesses
  */
 class SettingsTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/Shared/ConverterTest.php
+++ b/tests/PhpWord/Shared/ConverterTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
- * Test class for PhpOffice\PhpWord\Shared\Converter
+ * Test class for Shareforce\PhpWord\Shared\Converter
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\Converter
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\Converter
  */
 class ConverterTest extends \PHPUnit\Framework\TestCase
 {
@@ -114,7 +114,7 @@ class ConverterTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(102, 119, 136), Converter::htmlToRgb('678')); // 3 characters
         $this->assertEquals($flse, Converter::htmlToRgb('0F9D')); // 4 characters
         $this->assertEquals(array(0, 0, 0), Converter::htmlToRgb('unknow')); // 6 characters, invalid
-        $this->assertEquals(array(139, 0, 139), Converter::htmlToRgb(\PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKMAGENTA)); // Constant
+        $this->assertEquals(array(139, 0, 139), Converter::htmlToRgb(\Shareforce\PhpWord\Style\Font::FGCOLOR_DARKMAGENTA)); // Constant
     }
 
     /**

--- a/tests/PhpWord/Shared/DrawingTest.php
+++ b/tests/PhpWord/Shared/DrawingTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
- * Test class for PhpOffice\PhpWord\Shared\Drawing
+ * Test class for Shareforce\PhpWord\Shared\Drawing
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\Drawing
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\Drawing
  */
 class DrawingTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -15,18 +15,18 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
-use PhpOffice\PhpWord\AbstractWebServerEmbeddedTest;
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\SimpleType\LineSpacingRule;
-use PhpOffice\PhpWord\Style\Paragraph;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\AbstractWebServerEmbeddedTest;
+use Shareforce\PhpWord\Element\Section;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\LineSpacingRule;
+use Shareforce\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Shared\Html
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\Html
+ * Test class for Shareforce\PhpWord\Shared\Html
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\Html
  */
 class HtmlTest extends AbstractWebServerEmbeddedTest
 {
@@ -38,7 +38,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $content = '';
 
         // Default
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $this->assertCount(0, $section->getElements());
 
@@ -92,8 +92,8 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseHtmlEntities()
     {
-        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        \Shareforce\PhpWord\Settings::setOutputEscapingEnabled(true);
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, 'text with entities &lt;my text&gt;');
 
@@ -108,7 +108,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     public function testParseUnderline()
     {
         $html = '<u>test</u>';
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, $html);
 
@@ -123,7 +123,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     public function testParseTextDecoration()
     {
         $html = '<span style="text-decoration: underline;">test</span>';
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, $html);
 
@@ -138,7 +138,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     public function testParseFont()
     {
         $html = '<font style="font-family: Arial;">test</font>';
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, $html);
 
@@ -152,7 +152,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseLineHeight()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<p style="line-height: 1.5;">test</p>');
         Html::addHtml($section, '<p style="line-height: 15pt;">test</p>');
@@ -187,7 +187,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseTextIndent()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<p style="text-indent: 50px;">test</p>');
 
@@ -201,7 +201,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseTextAlign()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<p style="text-align: left;">test</p>');
         Html::addHtml($section, '<p style="text-align: right;">test</p>');
@@ -221,7 +221,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseFontSize()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<span style="font-size: 10pt;">test</span>');
         Html::addHtml($section, '<span style="font-size: 10px;">test</span>');
@@ -237,7 +237,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseTextDirection()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<span style="direction: rtl">test</span>');
 
@@ -250,7 +250,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseLang()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<span lang="fr-BE">test</span>');
 
@@ -264,7 +264,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseFontFamily()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<span style="font-family: Arial">test</span>');
         Html::addHtml($section, '<span style="font-family: Times New Roman;">test</span>');
@@ -280,7 +280,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseParagraphAndSpanStyle()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, '<p style="text-align: center; margin-top: 15px; margin-bottom: 15px;"><span style="text-decoration: underline;">test</span></p>');
 
@@ -296,7 +296,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseTable()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<table align="left" style="width: 50%; border: 12px #0000FF double">
                 <thead>
@@ -342,7 +342,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseList()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<ul>
                 <li>
@@ -371,7 +371,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testOrderedListNumbering()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<ol>
                 <li>List 1 item 1</li>
@@ -403,7 +403,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testOrderedNestedListNumbering()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<ol>
                 <li>List 1 item 1</li>
@@ -440,7 +440,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseListWithFormat()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = preg_replace('/\s+/', ' ', '<ul>
                 <li>Some text before
@@ -470,7 +470,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseLineBreak()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p>This is some text<br/>with a linebreak.</p>';
         Html::addHtml($section, $html);
@@ -490,7 +490,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     {
         $src = __DIR__ . '/../_files/images/firefox.png';
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p><img src="' . $src . '" width="150" height="200" style="float: right;"/><img src="' . $src . '" style="float: left;"/></p>';
         Html::addHtml($section, $html);
@@ -512,7 +512,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     {
         $src = self::getRemoteImageUrl();
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p><img src="' . $src . '" width="150" height="200" style="float: right;"/><img src="' . $src . '" style="float: left;"/></p>';
         Html::addHtml($section, $html);
@@ -528,7 +528,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseEmbeddedImage()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p><img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEJ7AnsAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wgARCAH0AfQDASIAAhEBAxEB/8QAGwABAAIDAQEAAAAAAAAAAAAAAAMEAQIFBgf/xAAZAQEBAQEBAQAAAAAAAAAAAAAAAQIDBAX/2gAMAwEAAhADEAAAAfn4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADO1aJcpCnwQpcEbbEuAAAAAAAAAAAAAAAAAAAAAAADJhY6O5yJvR3tzzFzuQ7lWS3lKe2+VRdDTN5+l7WOXB19I4UHegl4OvXr5c9ZhjQSgAAAAAAAAAAAAAAAAAMzdbpOb3PQ3d5oWtdyxpFJm8zn9yvrMcliXOqGOtucPe8inR63DiWnDpVneG+caDo1YqR3Y1oxW9IqYswxoJQAAAAAAAAAAAAABLWnSvdf0c4OrUj3m1Ut8/DoXeJ1uepqlrXNqaXpStHa3XWfmbR1M8zpFfmW+YcjFi+nMvw9G3iIoks6xbLDDbiipiWJdIbGKrt9MUAAAAAAAAAAAAWrNfRSdT0847OI8zG6bN2tQ8/GuvNycRdjiiXpcvTnp3IOfXlsRwap6Lo8Si13eWiS1c5PTNZJNKr+f63PKdnWOsRWo4owdWoUkmq6Ry5qqliwBQAAAAAAAABNW3o83PXyu5pMTfrVs89SOdqkcunQymqV5M9NYbesQayYl1huwy1dLMdVMz4TEmb9R26VlNeX1easEN4c/F2tZrJrmo45IiKCaMi03yRwzYqqkjxQAAAAAAAANvSUfQernHiCX0Zxer7ee3uHYi1mKWSDc6uK9bw9L9OCn6Ofc6tqx5PTyoL7Fr63KE1pHnNa4ubaxUuW5dTmdOPSteHb50s0OomrYEesmi66SRWVNdotZjxtHEkeM6K82SszjFAAAAAAAWYPX9J1a3rPJd80YtXoxYn5nX8+reZ4vJ0mo77SVIOtSijyrVT28fadGDTwepjbXG3OsVbmLGvd1jm25sal2STGlfk3a2Nctdjlp6z41KuuapZ102IK9iKyttvNrNCK9W1IYrNeXOcLNIrEMuozQAAAABkv8A03zPs+0eB9/47TlY9f470Y1NNS76nj+v+f3oR34fN04uZGs8GD1e/XlX0uwcO2jOZca6wm21LffO/wBulf6ZxqrLzIZIsaiitwVJFvCleLSMixiHWLleXq2waX61lCnc5xFDLDqbYarthmoG2vOgAAAALlT0/Sex6MM2em0kVrnNeV2Y8vCS+n36yCfE3m760elqxzKHTgWvLrtpvFnQ3q3ZI5UfVgk58trrbxw/QcLpazb4fU4CzZ582db5xBVuWCpc6c/0NmzyM/erWUOhJX0zzJeYaR51kjgmi01YzazjNYinhywM0AAACT6P4T6p2k02N/P03xpphZi2ZnnYq0fqeqxTseTtLvFLl4nfp+L9/l9tnbHi9FWzFLqW68dhNqdirmyaLDPItX4NZpyyyaziv3KurxtOjHLDD0o7NbGM2Uud1uWXK2sNVqHVopz8SRmkM8Wkec62tsZMx75K4xQAABk9H9I8f6/snpdKp59ybYl5aVp6ied5vb8v7efrOnS6Pk7Ybb8rB8++neb9Hn+edH11bra/S+fa19Fx4mbL1+3C9Ryus2ZcWWGav0zQtyV4t7RVK3gnkKlnGbI6jjlyv0YzlZtRENW1RsgqXKppDrndkisaRBjOaxJHtUGNtedAAASR2dT6V3udd0twWK3n6b7Yzz1rHrm3ieY9N4P28fonT43V8fWWTSbkxDZppX1tbN+d8L7Twvv89vHd6255Hpz0z103C63m10KccWbbp16R0LHHlS/a5Fau5y/N1e2fT1Of1ubq7czWW7pvrpyKlngalitLFprNDKs0UtXLXbSSss6GkcsWQSgAL9Dp9M/T5d46uQ0LvOyb7UuPeSKGRNvCfR/M+jle6XA7HHdvCv5+lyJzdZ7PA4flPXxRbvTm50ebaxrsY51nDPrub1MqEtqDjqpBauRyNutwbKXnJuf3mN9d9yf0nlvRYK0kfBb0p4t6PDuyacBPB0mJ4bi6071bKHJW+ddjWCxXyCUAB1eV1umfqtC7T1mOfSlmdeHndzn0xbk1l15nX4RxOz1Y7anG83zNu7wZ9e2K2ksGkksU0ZuQaZeg6vlvUYvQnho4dTHI7uLQodbk89eb5Sv6cSY3k3K+M6lrued72btXupIoLXN5JdodZc82/Q6Tboc+bVxrqy0jk0rO2uRBPBAZoADqcvo9M/Q81Xfn1NexV8++BfqyzPR6nnehjfQ4HZialqX8rwvOe4oZ381npwe/hLBlLLtHLG89KxlP6byvfzer5ruw5c32fF6+TzN3h+fXDr5z7MzZztZWxvISdjmegxYtLOscrndbhWd+pzZI2r77VnTbVcN9MsRSRmdtVbV7NbIJQAFynPqfSbPJt+rn6WbjdLy750XTqyUrHOlmvRVZK01NBPQz008v6LwPSVo99fZw03ztLJXmgyjmksGnsvM+y5Wte5EWXWi386XOBdrRSm6fHTsV9ot2SxFROl1fPzR2adzWOHUtwyc5JrtvrnJpmxBltHtFLmPKs4zkxBLFkEoADbVXr+x57se/jY6vAn871fEvwcdwxVtj0Oedc59ufHLxbOZxbVT28tZYpK1zJnNgxctxW7lenh6GTl75t7ndvmxiaL0J5CX0FuPKcT2/nipD1OjXkrPS3qhH0erHn+hPzcu55+XlSa1rNTSTGk9QSTR4Q6SYt1jkxWdtd5K2m2soSgAAdf0/i/Ye3lLFNpmYtV9Odtem8v6Xlqfh9jhTXl456fsxDBJitJpM5vfl7bheBy9eZt2I+VfPQac23i9OGmjqdLzHXju48/Uj0Xn+joVJkhU58lqqPVt0S157p0CjU2izN4bMNlS1rDq26+Ycm0GVznTNSY11IhigAAAZ9X5Prd8eq0s1u2dYpNObfscmxy32vL9Pz/SRxzVO8imisxe4l2jm3/Z/O7WXU5/pPSc78/09945eVZ5+NTrT8uaNejxB35fKzS+zl81ay7HEq9sp6dGgSbwhxoatSYis2Ynpbc0ekuNI9ZI5cMgbGIpYIDNAAAATQq9xZ8z6/wBnOjpar4Y6VDfndKdjoJyOd3+J3VYbUelmnYzlzsbYro+n8Tvz17O/4OTD3HB5OF2g3jshz1qpUi6m8cqbtyy0LfGkS7x7FNbNrlTppWmiqTSWtGDBtjGMsa7ay5NhvnWIo84zQAAAAAJvZ+G63fPs69jG5W6vMsYtuO1JzcnhdjkenOuXQOTTtR1U3x0CrjaOV1eXazexRq65aXefEel5XOkFvmTFyOK/GnSzbxeXzPVcCs78/opx4LdDTOgYEMNc3BmMyNoxDJXlwIAAAAAAbaj13oPnXtfVi3IYsNLueX3mzWp9HrM9Kp2fJ08pT6u3oxz03PXpzcXeOnU3giWarDL0I6wTVBYxHJGJN54sXuHJm9aLm2C9FHDEFHsYTzGOpytMa7amMZZuJWc0RGmhkAAAAAAAA6fMzqfSOz839n2nf4vao4eG060vrxX7dWXydOfx/R8DviharSaSy7aZu2d98q8c9ck2g3ljxbwUc9CeOXp2sxyVyArpIDGqudXPHR2udHYjna26kYkbZuqSAxBnEoQAAAAAAAABt2uHnc+j9f536Hvi5zOnvpDmOkXeB1+zL4ff0XL1K28G5csVb+LXwxEO+20tbWbYxnO0V8TihvvDW0G0caba5Na8mYgki0iSJvltnMcuarEBKAAAAAAAAAABnp8tqeuv+N7nrx0N+tSjnTwQ6de35nOXoPNdvq4vgt/U8XcpW6UdXLHKt5tyOLENdkR40nImY5cZ12MR76Qgmjyj1k1jG2sUu0LGQSgAAAAAAAAAAAAJI1dz1Pzux1z7mhTu9sw6751Ic6TS9K/5/GL3OfRtRzK3rtTzVL0HMqlvjSzoQQT5umNUZ03hlziLEZ1zrlnTTTNzqZoAAAAAAAAAAAAAAAAGbFZZ3ej5KTrPZVuB0+mbO+JqrxzVK2sU8R3LPk8ZvpqFG7m06nSoWNdYc3aLTTKXSHXNk0wzQAAAAAAAAAAAAAAAAAAAAAN5IFl2XmtOnnlrOnrzheUUt2KujfXDNAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAG5ouZ6Sku5KK1vFJayVFjcqLm1UVzWKqzKUVxVNa3iktbFNa2KYxQAAAAAAAAAAAAAAAAAAAM4KbEagAyDAAAAAMhMBf/8QALBAAAgICAQMCBgMBAQEBAAAAAQIAAxESBBATISIxBRQgMDJBI0BQM0JwYP/aAAgBAQABBQL/AOr4mpmhnbM7c7Zmk1mJj/SwYKjF4zGJwyYOEoHYrExUkXDQpiYUw1idgGHjiHjiGiGozX/NWomV8RmicIxalSEw2RdTPYMEyLEnbJGmJ23nkQ+5hxGxMAxkEKTH+QlJaUfD2aV8JUgqGe2DO2uLsLNC8RPGkbi9wjjKksYiIbDCGj5SHyM4LGMsKsYVM1hExNf8RKy0q48o4eAWq48bk7RXCrsHsKrhu2szXMET0oBgjSOomMBsy57RO8ZsZmI2a7WIJy81MIhHQiEf4AGZVx8mvjQGqhW5bmb+qs7EE47iCNb6i6tDYizuq6mtrZWO3O7gq4eEQmMuwsQqVM/XlambyH8bZmMwrCOpEx/dRCxo4swqxmGB6oyLpAxBTMcHU0lql4wEPHrwlaVTRte4qG0rbVVshDZj7LHs0mC7rRiMuDpsliFG2g8nzD0PTM94R/brrLnj8cDoqCahj+MXjs8HCrwKqknnNqtsuqs9wEblusS/IfkZLvO+0oTurlVlgGzLmU4AyIyAwDxZWHllGhCTQRl86ZjKRMfQR/ZqqLmrj6iumPYEPlz23aIq1M/LYRr3MW1kr+beKwYF/BYT8rD7n3g8FuXhUtIbuzbeJ7gePaM4EtsM2LMQ0HvnaYhGYUmJjqR/Xrr3NNesXxDaYYlelTWeO0+jnJpoe5tKqSX2boT4GAds9MQ9RMbGnCzdY1nh2YsFDMVnnEGcnoTCIYZ7dCP6qJuaKMLsojt6hKkDB3xBcrM9mSqbsbTSmS0TGO8upHjWaTSFcTExNZrAmTWpSEMpWnItrKhgc5mfWyZjLgjoYRCcQ9TPeEf0wMni8fw9mRUPNZzYFm6otlpc1uENe1jghJY6vZ7BbFyOGchPDgKFXuH/AM+lxpNIawAFBVU89t9VGbMS44GQGbDDwGbBUqJjoYY3v0z194R/S4tGxfCLnxWwQIoVRYrG7+Q9oYTh3PGDqwrwmcG1zrU/buQragWXsRKl9LeA0JxAREC4RNwlWGt8VpjWy5UF96mN7YmcwwknoBGhMaZ+jPQ+f6NNe7cXia13U6zC9vy7XHxVWdEqBhTE+ZsRXPcPbOAJbV/Hgk8dLEdjsjIDBkRzLGAm0TwRbhfOtSBVMaXpmdvE1mMfVriYhmIfczEMHQj748z4bxd2x45l62NFbU+8WxRXSdVOctklEyT4sK6mxzYc+oDFQfYnofUbPAXJlPFUhlqraxHMVcKw9LXTuQ+YZ+yCC03KzuA9TAhM0IDCa+T4hgn7h+9xq9m4tPZpb8LFKPA2CYo2J3LVU7L2FI7OkHh3T0NS1ZCb292y2YzMtjzAMx6yx/5xWLRai1gXUb5awelgcnxCTPeAYVrCY3mMgxgwT9a5YJgGOJ+3P0n7o8n4ZxxkdOTU55r/AA2scdhqQMkzgccFvAn7LBo//QHaKqsBWomkKkxQR0yRNjhnyKjuyFVGcwribMZbZYzecHEPiZbNgMLYm8Y+TK2iIsMIlpnsT7/SfucdNn4lQq48Hv2k7mJy+DXyVPAYW1/CrQ3ZUCY8+VstQGYKkjwvifowEav7k+MZLJhu3Yh+YKspDKzahr+226zzj9mK2DndTVktS07TGDjMJ2NoB4ZvD29DDD9J+58No3sPssGTd+4fELFH7m7A+Rjoy5DBUnIEVsTwDmfutMxlUgoJ4Q1sO+SNe9q9GDXa3peexDeCZt4UDtDIYeSVBXUZZgTiewLbR/eE5hh+o/aQbN8Mp1T3GMQDAJx0f2+I3GocS3PHVPBgMzPjDOL/AIZZvVjyfKhiGYeaz6WYCanBXdgMWW2F52ziqwoDYLIBtPlkjpgss9GyqCMAEeqfpgRF9Rz4tzoCBGHnoYfpEb7XFXNnHTt0nxPZVJn/AL8xvKfFf+fw8543zBMAhi4M+McbuU8fkvxn499d9VhUREBYpYsDYLBYXncNaZssCKBNPLhcmtIgAYAMrocMonywzpDSJqFGcR/IH5O3p8tWq+hl1Zh5/bTGSeuYPdvtfDatrIZks8xmH2sfx8UwOP8ADnWIF2UT94weUpbi/EeOnHdXZDal/wAvTyeO9emZ2WE8zts0ZMKnqAXzWssqWdpVi1jOQk2WOpd2OGB36Osc4ln4gZhQ7wYjsCbB4h9l9yIRB1/X2fhNfqX1PAuLII0YBZz1W3jcEE8umskY8DEx05XwpORfx/hVNFvxKo3h6rK4rMpPN5Mr5d2a+TYrlhbWi4A/JiYbfJ9t8Hw0cTdhNQwxMhJezzubXa7DXEb1F11GBHEzG8TM/Z6H6D9hBlvhSYoT2jRB0B8tOcwXj/DrFTl7HAiiD3jnAyY9YZbeHvXZX23SncGkpAWA49vbdbjMme6tEAWXvFsaJfmNdtEt8PdG5E75eVIz3pYI3T3jnR7bgkD5h6AiGHoBMdG+xSM2cL0cFW9UJyf1Mw/jzajZx8TjkvWCTBMQ+z+YEhHjnc4V1CcSjI7OqcmsYCYHGvILOwjW+GbWG7WbZLZYL6QTgWWaVnmNgXvOM+WHhi2CbjFbKn35Tepjkj8eizMPRYeh+xxR/JV44Se9jaCeclvBMz5avEtGnJ4Ffa4w8tnE2z019U5vxCmmWWGwxeQ4FfMfNvLrNpv3nDrD2hRjsmMxmi9y2sxKroV1NtgSu25rOijJXKMrG8Mp2YGVXaxr8s1qPL6tD1UZhEPv0E/Z+xw/zVf4xhTa5Y0tlW9tox8is7sDq3BDXIO21TByfAUgEtifP0Y5vxPaMxdsTWKs7Ox7BArVpxkAeyE7BxFyrd5Ug5lbHn8nR7eVY89zFfWbHNfOOjWQvvMz3OYw3LoVPStY0I6ifs/Y4f5A+jJdrPAouCxLAzsrdwVmBIZbbvTxns7ypYim4EW/EaVa74lZYnQxffPndot1ma7TZCPHHGocgSk7IVM20N92ZdyNI9hs+n2nERDTbQ0rpfNlXbmPBm3i3BEWAjVj0boPc+/2OF+VZzVnEOWRBmIdXrZzX+lMMp9LhFL8h+1x7me+z2KDaWYyykdBNZoJkiUlQeMFcL6JzLyJVb3HEasML3BTkDF4ghH0UgihnbCcjVuRZsq3KQ3pPvG8CCZmfMP0fr6+H+Vb6BfWliHtVpqjv5o5ETlBiPbHlmD2p+F9RsS7hoaF+EYsuAr5C8llpM/fvP0pzKx5cCk/Drf4nVEe0NYUwoH/ACd/TfZk8g7XRIxmOihQFr2ViwAUsbvTStYxUKjTkSx8mfr6z7fXxP8Ap+aVvozD+Pt/xvVg/L5AC0rUWZC2Ai1hB5BXMPiXW9uqxzY5mZ7ibATKiBmaDLzjBVpqS5nt7fJbh0BIzajlM+TG8P7xK2MsACRPBADSpcVOJV6X5W10MDkANhZr1x49p7Dq32OOf5eH6pYqwNlV9uQnkXEh3GvFf1a+CAkTdQ13nuPn4pyC7MMHoIojHzBY4lDu1lVDa/Lqs+VoeBVRuTcdNu9TyLVw1foouFZfs471Yg45ud+Mqw1VqVIDOomurF92NKiAT95zCeg8zPRvob7FRxZxLtQLDW3HsVilg7nIwErVVG2bdyr4LVH37ixq9JdalVTnMPQQCYmpldXcgVg3GRBc5LV8i21ZwXsVrdGPIUFlYVL8sbI9DLSUUGkKtSWrXDzXi3EstxiXbBDlT5HIp1BX0MMQDoq7MQqT2hn76frEb7C+9J/jY7JS/abj2q0sHdqLMjXaA7bWVv6F/Mhu/a38nK5Autb8oghHkQzVpTjL0Ix46qGsC0RqajXXtVYE2svuG3yQL9pkNhtso+XscnjuEag5/lwnGZia96qaCYHZJW2RqCvIH8tuIpnnOCZjofMEPt1b7PDOyofQ0pftnjuBWulnIbDxK2LJmIABuFv5N6vwx6h0T8mBaDE7SvF4YaKqUTY2WBe2OO9ljfJtenJ2Q8ahNK6adG4akpQFHMGlViqkoV7K14wqFjWSpbYww1ecWJtM9tn5RVfVn8oQRCcyv3f3h94ev6P2eG2Cfy/Q8MXeBzTc5BXif8WwYzWVtc1hve02hvHTHhRBwWsA+H0vL+Lx+Ii2tLOT4W5sVp3E9SunMAG9N0SviqKRtAJmPYFFlfedKrQCfFhzFrTuDJNe0cZNqZN3lc+EEtTWGL4XPpPUnqftUNrYh2r6Z1jPuykY4hXsFTjl3tVx9msU+ITBgnU9tD25RfvU1RYcsst2SYFaV1+K1Rnfj2kV8S5Ja/Yi8pCy82kS/wCIBYbGtma2r/jrQVMYyKkc1Ma3WYUR3CndpYxaXMdVOVDYLITDqRmA5hPTPnqftD34j5BBHQz2M49us5F+i3Wi6LYao52LSinvPaqaSnlNU3C/lTm8YV8jtWGDiWGHZEDgn550ickubjUVIRZRow+UQmo10sbe7ABWPKh7DyGSnQYOa38jtEsRhr2YhsTc7ZhcisnJmfrP2+JZg53r6YnvKxiP5GoEu9RhBlIAs9RjDVgcEXlTxkTkJXUEnIoax+Whcsjk/LWTUJCy1191ixtwveaLfYDXfdax5L7G+3kNTVXUCvrc5HcGmNZyH3s1JJiUMynwc7DHkLCP6VbatxX2BEPRSQbmU1uSzfLtt2GqDEMMz2YOXSxTtMzjck1ynlhSfiG8W2mwW08YTlpvDxyssXwKWM+VMCosJm5iVNZFIqi3tGv9LXkxL7SDYVWyzz+1TYs7N1yZn62+7xLZ+aETExHLTysWzRb3ayuxN0Q6sfJVjUbbe4sxmIdW7pMS0gLY2C74G2TnXWUVPlqbmYcRxUnDLROEqW8mxNcGJTLjiHxM4i1Fo+sAxM4o+wOh+9W2rcW3YEeCIpGzVIwuQRK8U3VVqmhQUUG9Xq1rt9Y1wD7hDqK1EajEqCbdmsWLRUBa6I5s9TWYsD6yxu7BdbUWsdItptDLEXLNWdbOE8WrZvlkUWWVrNYfcnx9B+pj9/i3YKNvWV6UuVPptVFU13KiPdcdqOT2EpUciWqeNduHAxql6JVba9p1ttipYpT1xrLFinuAjSbNh73cjlMs32myzOJUa2RWGNhXCS85VerJ3HnYKqVJ+0B0J/oKcHh8jp4LMqCDJsbkWC2+xbRyKcP8tXrx11nM9Vq1Fx8o2i0orKyVP3VJe7BN+YtiRjUFPZwzUz+Fz2q8kVLCtE9DEU6BJsDDZHUNBhVYjUVeq+iD3Y5b6QOpP9GqzRuJfuHXwtRaGvM5ClbR4J5e1db5Wv01Occo4SHk+pj3GxidsiLgQa7HGNQZ2cg0YjV4AQQooKqBNVmiwprFvKw8jJrtyGbwHAOfMup+nH0Mf6fHv1NF4dahgFFaczjp2dcwoRKU1Wl/RzMJHtyg99SJrgL4n5wKCSgWexXG22JljNSJiCtpo02InqMDsIWWACEmb4i2ho10L5VgD0Mx9BP9Xi8jU8fkgEMDLxkKPLMrJQgFJUJO4MX4FpEDYg1aHEU46H8cYmoMAmvQLB4UGHBhqqnYMZXEwGmrQ56bRX6WDoOpP9YHE43IxKLpb6q7aGcKXrevloptvwuwuRyCceFMxmZxKVzDUIFnZhTzrNTM+VPgs0Pch7ghZoLDGsMyJ5B2BBUGEY6bxm+hjCf64OJxuUVI5DsKuSWjXptrx2DgrKEJZ+NTZLPhxnJ4jVAe3clbhYxGMzYzYzzCTPce3TYCdwRyD1J8THiE5h6joWhP9qnkYldoMetnny7mJZZSbHXZbmwvKsxXzdhfw67BbQ9RmxE7rRbQEF03abzuGZYlmmwM29W6ZPTxCYYfqJ/u13FZTyNTWy2JcpSWBcY8eQVtIlXLzM1Wi/gbx+FckKnqLMwMBPTDM5UNhhnBAgxA0zDD0Pv0zCf76uVlHLKGrlpcttYAJXLDMAE7eYtmoq5LYHMQztUXx/hxlvGauARgprmTFbyACpVoozNYRqP3mFoWPUmZ/wAJLSso55EJrtnlIHwNzn3AAh2gaJyrUK8xGjUVWA8N1L8ZgdDMQOQBZ6fSZt5LAzJx1Jhb/GW4iJyzEsqcdpWjVFZ6lmTDpCBPUJXyNCvNUwWI8epWhr1jVAzQzQTAh8ddoW/yg5EXkEReaYOTU0HbaMkZT0ZMTJmSIvJdZ3Vsjw5yTC0LzaZ/z9jO6YL2E+ZM787s7s7k3E7uIbzO4ZtM/wDz1Rk9tIalz2lyK68dtZ2gB21yUXGo27Qx21naURUQg1gQICBWmRWs7SztrO2s0E7SztjJqUH/APAf/8QAJhEAAgIBAwMFAAMAAAAAAAAAAAEQEQIhMUADEiAiMEFQURMyYP/aAAgBAwEBPwH/ABVll8xvwqK5LyLhcxuyijTmN3PchaiUUUUV4VwW5esIa7nqY4rEpt8djSShFIaO0u2JKilDmuFj+nUQ8ajDH5KRR/ArsqXN8FmI4XTVmw/JwuF8wkUX6hMaNsrLUIbNxqL4OP6IYkZf2EWZIWDrU7juEy+GzHYxijPRiMjHcyyRlksnpN6eNsXuvaExOzLMy1MIuhv8Ekprh5bT3QhOh9Qu/JQ/Cvcy2ioTlYLfkuFCQjFa6nVyr0r2PjhfInHTz7o7y795+5lvOGKxWg+ZlK++y+h2hwkuY1DhbD5jX0LRVTfOrwvnUV4XzqKKK+jsssuLLLLLi/ov/8QAKBEAAgIBBAIBBAMBAQAAAAAAAAECERADEiAhMDETIjJAQQRQUUJx/9oACAECAQE/Af62jazaymV+SoNnxo286K/EjptlJeht4U6NxuZfOvwErIadex+i0vQ8X468yViioobG/wAD35ErIR2oYza/Q8Mssvjf4Olp/sa66J9vohtj2z6Zeh9M04/TZOTfvzvw6cb7ZpzlKXQzUTUaQ2y3jTi4x7JPsvCzZfBcWvBP6Y0fx5dshqRn6Ga8+6RbLPnklXBZrivJprsm77H0KTi7Q9edDfKxCYy81xWXyX0w/wDRjxtXx2OOEvk0qRTusPFiEUVzWXy1OqReEQ702iQ0aGoo+x68d3Q9FP0fAzU02hLx14I9s1e2x50VcGiXRY1QjQjJLscj2OPeLLEfGSVF4iuT4af3EhoaFE0XTNX2UKLkaeh+3h4bKxX+EIViSynyfDS+4/YxrLW5kf4y/ZGKj0uDxJDIRSV5Z+qNuI8Xw0vvJoseGXR8svSK4PEhsXSy8RHHk+EPuNROxrDwz+Pp29z4ywhQp2QlfT4+uy8Pg+L+qFkliUawoORFKKpDxeUM3CLLLx7Ij4vjou4UMaJEY2xYZuYkVlorlJfsixleHQlToeJGklhiJRs3UKVlIoooo9ZrG2iy8vknQ3avFEXQn/vBxscBRxZZZQvC+elL/ljHiJJ17w8MooorDE/wU96xppMar0Sb/Yn0djWK40Vi/PGW1jVq0Q6ZuJ+yA+Vl8K4vxwntNql2jtdG1Mvabk8Pyt+WMnEjNSLvplIcEW4m5MoaK8LfnToWpfsTy4opr0bv9E1zv8NNoWr/AKKZeXE9Flll/kWzez5GfIbzcX/Q/Gz42fGzYxQbPjZsdWKDZ8bPjZsZsf8ARf/EADoQAAIBAwIEBQMCBQMCBwAAAAABEQIhMRASIkFRYQMgMnGBQFCRE6EjMGKxwUJS0SSCM0NgcHKA8f/aAAgBAQAGPwL/AOimHpxVHp/cvQjhoUa4PSY+5Y0sqS+kZOFScX7IhUov+xZXLvyYMfbb8PuWUvucTntp/wAHCpJ27UYfydCWzH5LGPzpfSxYx9smNvd5L5LWN7UCsyKqncmPk/sKcG6plr6WVxdSxeY8kstj7TlHAt1XUyTljbLJE1JySlY9MQd+pZkVKEj1Y5F9XBezfTyQW+zzhdRKhfJCISI1pa5ncpmxfJBMj2uDiuRTliVSj/JYZCOZNpGKSH9nhHEWwWzpdnClPe5ChdTMIm7OGCFBmkiWe2m+t+xBJyYl5LrSTv76Z+w9iKFgmo4UcV2WpgySkiKs9iqqt3JmTdUTHlVPh/ku9I5Flc768j1WME/YpGuWk1ep4IFXVjppFIqa77enMdSpS0xcS0xrbycJxK5nRy1BxSWuvYz9hksRz56TNy7ILtuCDZ4du5chm1tHb+U4JYuRiddzgca9/rZZtpwN9BzpLaO2kJSQ6lboN047mSKE6mLxKn8aLq3CHfHQ4iznWSf2LSP/ACJRJLJPUy1yGcOPsG1YO7L8yXzM4JpujNzhoP06pXYVTdOJyWIkpr6MVVM30UJHQtrk450kZg4hJS5LU/ktk4l86WRf63e+eBubCfMgS0uYIpiDc6ad3WDmbWrjcoSWWTVBVTiRXuuZxOTGkE1YIXXAt278liDBz0xpby5+qU4WTsKmj0rSdJx0JemCJgUXG9aW7WwW16EmF7iqcP3IUFMXnoJaY8vbyvyL6ZLnzGh01ZXkg2fqbvYT0sX0nbIml8HFw09+ZKetsnKCUoq6nG2ZuzqRrctjTczBjR41S+o3PFOu15rdhqi/icmxp5Wu7xCNMPW5w56mbmSOhnS+nFVCXQ4LyXOEsyN0+xLYtPc7azptZP1CnnfSDft4oidLcNa5n6WaifEjajutXzg3EM3L5ESzvrYwKlfsXhCe3hT6E8vN2L4LXL0/JKMQS9LaNfS0rWOS8nh7s1O/4Gly8rqqZJfBBtL6qLaTHsOpjaiX2LMjmMxpG65kv6mTRUTBjTbpU/pkh1/GkaRp8irXUpqgv5Ep4WpK/DfJzqupI10Mm52G1yKWbadLHHn/AHEeJjqjdOt2cN/cnqzsQNk6WPf6amnotJL6sT7jXSo28yZ1/VpzR/Ybpi/UVdN3zXQltL3Y0ciSxCLK7ZiO5jTkK6P8DWBQrnFS0+pashssWxoyCOZE/TU92LSPIqep/wBxV4b9TutFpJ4iWYPDppztmomltM/V8aqqKsJ8yhfqRVCUM4ap9npB3E2sZE9LmCHJ8HIu0hVRYtQYjVKRLXmMvkn6OeiOy0b8tVsXTKYNy66MWj8V+I1PI3urfGE0f2OOhomltMv41f5H/Fqkpl1VRyE4SnSCxtLXMMuWeS8bS2tOwu9bE89IRD+iRXV8fyK+1MC3c1AqVZrz3KqJsx0ynHQmY06FPFJal/JOWTpKZ0JdWC6RZJI5FrjnIkyp9yJ8kG1ZH9Eil9dYI0tpWk76eFXzdN/LGu3wnfroqoRuq2lkcKa/qNniO/JijmdziksS35HUONHTVz1ySSW+lpX9Ilon5vGStdi/Ut0Kn5qvDql1RyL6WqYt978zhU+5G1J4wXq/Gm6YI2yXpLeGrkfp26kNG6u/+0u9LEiUYV41vLJ/YiPpaV/SS3eBaPWlyMq8Wv0+orqTr27bbiZvpfJI6t9kbfCdSJbl99cHpqaHFLLoeJELRu5LRtuTuUdCJt0L6WL4EoTJ5aWL6X8l/oFU8QYyNEM7CS/JfTI6MSeJR43FFNjdBLt7mxJ1MdFNNKTL+a1i+xJcpJOK0in0sutr6GTJFI0nc4vjzVVNNM4GcViX5LfSKORL5jtpfOmNOJFkVVPkNuptd3rZOfIrlqvktc3VVX6GJ7lvEb7ChYKPEmG1dEkkbEn1KvNBclUyQ0bi7j6aX0G5ENiaMipSvrkuOh+k2+F4dNL6wLfXK6QeJQphOD9PbS1/UvLHMjBmTjfD3KqpdKI/WW08OlPd3kRGj80zf2MxYSTsWd4uOSXVBVd1NcyzI+joXYp6TpY4tPTc3U2RJuSXuTrXW3alDqfPywyfwTSiXdm2qzN3iOrasKCySdPSxuqTJ5czouQ2PRuHYpaeS2lnc26OIkV50jlpcz9FPJIsrybeeksiFBw5ZsZciSIOen6C5XZHn4WxUp3Zj3OKtqOcn6iv4nUjfxdtOKOFmyn5FUkXRVXTWnOaRf8AT0ukmnwXTR7l6afCXdyUrwqt3uX9PUZ2KlTgf8Sn6VEch7jdN+Y6RkvpkxYxekW4xgs7sluR+Ix1TxN+SdeFqehsqW0VUVSil0VllPYqfiWpF4kfJmuin2GvDvV3RaKfc3RzGS//ANG3k4F8m6qWxuIKqauV9GKqkur+X1T7fRUvsMt6iUymltbexTtzzXQ3di7ljlj2RC0pX/lr9xx570X7oVW5Us2OtNdkKjwFM9WcdvEfSoiviNzrinpuP0K7UvEmbCqV4N0bqUTtj3FxprobVBh7V2Jq8NpG2n5G4fyRNi+kMla2+igjRyOTZHyVNdSykadmbuZW6qolWGnKqbO+skxbS0nrI42W3UnGyra9qXY4/EusVo2Lif8AuZxul1c7kRMdeRzLkUUv4Jc+zJnbJvq4nBZNUi21U09WZv1MWGuY1k4TcuZf+Tf+bPKrX5JQosUvno+g27i3eSDw/wBNJpoidvW4q09z6G51KhFt1X9RaxNUfNRw+KlT2Ob/AMjdfPseikminaus6WJbG6Yb9i/jfsRukSZ/DY+HmJRo3U3CE9u1YGi4uKdJn6NdtVGUOclxRZjcn9ZfJGl8CfJ4N0dimnhx+CFFftYajbHIl1FpZdfJ6hfpJtdya3RQn+SEpX+6CzppXdHF4k+xFFL+Rbqop5odH+nuWRlnTqzc1PRSRamT0kJrTZSrcxUq8aWJF2+kXmVyUVPqyF+UbpkwZhK7JpULktE1dj31RPJMe2vd3ZP6aSJ4tiJdULkhcF0WYt7kVMsxk4YXubq/Gt2Ipp3d3zIX5ObrKq24RteOxNVPsOFtXImqqWVVvJubjohttE8zs9Ov0sFNXkXUbqwskVW9zClErWJyVXwQyxS1yclE1Q3diS2wKfEijpA4qdXfGl1BZtiTpdyaf3MnUlIl1QkcL/Jsb4OxamahurJMuP7m2mk66RpvcJFnKI0v9HJt6+RNZE/9be4nJK4l0HXeCZvpJtqL67YlDqeeYndU5kU+Gb7KCaWtvQlOepncQXqg79ziIVQ3XU0u5RDn2KplfJZEI2qwlOOZZJ99G+SO31EG7WSn203pX7jfp24g/VoVufY4iy9vLK5Dc5OFjvdnqLt3M2FMpFW23/yHNvk3Tcmt/CON0vtBVRuXttwZJbITscOCxueDhJGuv1UTrItr7k2RfqVVzw1Yhk+HV6sp9DxLWSkpjK68xRkbdiBtKYyPfNKH/kiqq3Y27k7cieacOR/w/lG6mLdSh/p0ruuY1ya/BuUohupdRVU188D3THWTIjalbqJzCI3YE27dDhwOU1pH1UCq/PkiqzHTzRNW+IwRmmCqJlmytzOGOlO6HvyO9+RTw8W6/cedpztpxfkafOxFRG1GGXsYLkUux0k9N/cilWEuZf0k0203VNJZsOvdb6yS+NOITpZ0RCqhYkmapVs5KGnNNSyS5kbiLDqJN035zyOOpbXzLNWyRtuSqUf+GmRV4dS9jJNNSvk9ZfxH8k707F3BuTnsJOonchOTo9JZFo09UJcjdRgvgcY+r2/glaQ3DZUtNtSxgTgvzKm1NL5dTdTTtTWJG+oy6ksX3XLJmL6f8HOO5gnaXUDwzkSrcrChzBxSXQ0ZLkEm5fW/3JWC5KyiC6EMbSlWRt5aRafYkmlScyIOZDHaTJApXzp20zBZnEYJpflvgmn63toyHTxDnKIu1JNNV+htr2z3IdH40xcpi3/cem/VH+7SDJKuiz/BchI9JaC5dHQ4ay6TOhZ/Y10LCdOR1R7nSmrIq6fzArUuoadtIJUEQ56nFOkEmDmYZgwek6IscVOljBa5ct9hyJ0vHIh2Zx0wy2OhuU1UCqo4qejN1Sgnw4rp9zfte3+xbXJn+Rfzv7JfBNN0SXpVXubqFt7Hqfycmba6JTN3g8NXRnF+3kc58+LnEjmX+0ynboWN02LaTgmbn8Sn5Idz+Gl8GPJxadTMnKNIxrJMfaLM2vJjT/k/wcLIrOHiIrsTb3RZyY0lWfTycizGX+2Q+JdyaHD6MuelPTEaWhnC9tXYjJxKCV+xaqwzGkGLljsWX22Hf3L2Mr30sZZlyTuRZ2OhxJoyixfBb7peGXTRata5Jk5li99Zkv8Adcsz58/+4ENwes9R6z1nqPWeo9Q7nrPUXqFNQuI9UF6z1HrR6z1i4j1o9RG//wBA/wD/xAArEAEAAgICAgIBAwQDAQEAAAABABEhMUFRYXEQgZEwobFAUMHRIOHwcPH/2gAIAQEAAT8h/wDq9uoNx8xb4Ly8vLf3IbRGzLftThqlm+kIcQ+4ecJbwO2oe4fUNGoTf7Ygun4+L4lxyA4iiU/2sF18HWI67Za1cDsXncq2PzFMXX1OWbc1KQAgmVXqyMaQO3McWjFjOFyov6ZxK/mc+YHKES3lBSH/ALks6r1OnMayv7MC6i2pQUp+UDvy8AFq6RwGvUTXEDAaDN7hSHtO5TVxc4SlG14lQs9EZuj5heq+odvUM2ESWF8wZ2LoTFM5eIqXGoGoB3FdfCmMJX9jW1iDZcq/5I/1O4eWVlXYc4ge0e9svWWrupa2Cvco01gw7r7QyHLWJk0j1KJklMwWD8qhWfZgphcSajwmFHUuwGIWKepUfkiWHS+5RsgviKSvhp/sCKgjlZaymsHl1L157MQUe5ynzMpRQZDthwofM1C0sm5beJSh5UxgPg1Dks0EWwDiox4GDDiCNIGoO6+pedEwd+BHax09yq8amVXzKGN1M5bTKO/iVUYOMXmZI5+Fp/W0Il4L2IaKcrbM4TSoO4FUpICOp/icsbjR+o5YgiyDcCu/TmK1F8VD6C74CJs1+eWZ3PVLXMHP5KnE03zF3SpYy3xLlBnLKTCbywwoXQi3twWMWo3CGFMeAmDqOyNpr4p8KIp/q/CJQWfUUay+anVBFCjnQM0Cj4Rq3BWZkKYnV3zAXSAMglXqcLxDtG9wwfzRTsaqLchX5hIvBfM669IaMb6ji5pygxsH+YxZ3xHN4r54mkF8xLGpn0zOlB6zdy5zZ4JU0gxofCKqcy8uMjFfG9/1X4BK3FS3GuXn4KGZ+KVtR2yhGWAIR3eZijtj+yI64i3UpxBwHEqWegILoiBy4nM3NGtx0st1ozSWhm8XFJblubhiDTWtiyVEaYqm5tGoMsTXTN0PaWGk+o6xMyNzBa+4J8xo1YxUqz+o38MKlGuYaUrPcxFDTE4d3Aq7/CiDVrOEFdW3NIVKXe10RXPOHJ5h3i4AiKP5usSqOEWbpFkCsaOES8VPOYCCpVMHuWUNEVT+yHG+fEd9H1LruuOIFE7HcHWR3eoua0c4MEYKE1YC8R1OyG5CCoLiMOT+m2EIWJggbK14OYtC3t4RYzHSOGBliuHliU37I/VgzqVAavl4lkKXrzHsu/MQ5HJEFguGYVfgTe6hZxzCuxqbkcbjOXxaFxHG49JpwcRT7BdhMcq7Jw2eqmRY0wu8hMNa8wCg4d8Rak9TROZdVBvNlzXW4qpjGOJuCppKn+jYggGgGVmOqH7wmppHZsks3FkD63HLrgTIbrmov+vUrrFZtdywXPEO1BjcS6Ly7lAOcsW4zYmEeZxhfHaAujG5WHU33KVUQtGYa/bBdUbrwhFfolOg5uLn7FlbgudiNg5HieBmsSs4+phM+UzUck7TE7TTO4bhF4jCjGNjMHzKH+iQFMuoga23tiR15GKUSbYHkzfZ5TYf8Mprl+2WNjXMpR5WItIclxbIxAdjc31V0w1s6SYckyEI+4HHznODcuu68kTHjqOno15ZnxxyTJPqATxUqKbSwUqOYgiKFftcNVpFmmTpLcW+5whOMMxFxF5hxXL3Eu2MHr4OIaX+Ylf0CD1KkdMI4Sg1cQbd3UAH7I2di9QluYfhfjuAcYDCmjyshemKFKjppm7CRlhZxbuBKtKCJFQnDqVCtFWQQXooitXhMt4E2ln1Eplm48yHMrLH4FwJx7lMrLd/9INLV2twYtNKyJTKLcS/DPmL0S749BgcM06qYWOBqPsRy3cOJ68S2Hw2m0yINf0ELVMKc3+sS5FAmZrl7YxWG6l2hu4HAgo19RMNYjoRgR8nNRBH0vzNTZtmeaNEwL0zf9TbUtLROmNBEo5BmjmUENnmBdBfKJzYbgBmHDxDgMv0lGcEIy3CLIyzgY7FZfEdFSroZl8oPKXveYwUrZd5I3d85lIrqCEYy/M6pkgzDH4Cn9bL1MPZ59pmHaTb8ZjEuofDFb1FMoe2DTx9IgBjgWNAiV5nJBEBm4yyi2EfwCVM4RpLBgXG0JFDHJxBMNnfMsqrh4inIIAXbpcFXhi4IFeF1zLVZyV/uOAwCjxuM0CXmIfFHHEdSnj/AJj0iHVSqxo1FthEWGUuSjTb9SrdQRHcLMZIaIQShmxi2TiKOeYMFn6owR1TBf3GpMLFmbJeGEdgyIm1FM8ARZahFqKwTCAAIOdRCqFuh9w0q4lJvZqXFlmKYpgEkUredANaZZaQ1qkdAr0xfRXqbS2pvPqMw9V3YZxD8SjfLdxqAWOVijAOqToEGhzWO5cjiOo4ycRN3cXaSJvrzHaqiV6mS2h5jCu+4cQKzDcHeZwTummXT8Hwaf1KPogDtml5qZ4PuWFhNHQjzNzQOkD+ZtDtNTsvKG7hSgEC1hSAy3Y1VwXhe/jRXZ4DEjTPcPsa9w86jKJTq4OevUopd9Q7R4JZbK20h+IgRtQ6hqQMHtfxLVlZV1F7MK9TLhB564lbG8oVuGAspW8ONS6FW9GEsMXqDqfuihTUbMNVCB0hWr94aU0xbzP5zLfwfkgs/UvAwtvqFs/RDPCqG3U3mMN3iY0cIeUro+7DVjHMJKupUFqw1O8PLeKmkZDqEqtbfiFBOtQz/ZHYRK68REJf3E04IW6ArC9ytyeRMYhIDiczgQ2AT9iVtJjg3LKG1MRsDaVkb6gO02yzwI+7NGOJgxu7vUvwnEz32uAgq/cuOFTEy5cZJicd3FigvjH/AAL+axBT+npcp4QFV+oaG+fiLh2msTEvQ/mEIKavpjqAvDU3MPcpdE4JSWN1QRntpD7m7DZK14Hh5gGmDiuZhrZxBEjk6i1n7IccVjMfWJuXAZZjBcyxq1URGKmbmBKXxbUobhnQRCr6e2XV5o4h7vE/2hLIvGHFKchuXpWfMm1GVOMfAFMty7JANMXI8/8ADvKmPh1c5kH6WW6mAuz3FQg3rLFfwjpnzFoTYckN3rxP2md86YVvyMsczNsfAU/MEAGqUkUE/lELvPdUQdCm1gFtj3MXuuRi8vH8QqMAdty5CebBkQeaQWj7QHCdsl1ZK0y834VBh+Es1tqruZpzEZqPAB1A4w/G7g8WtZQn5J0ZizNSlhjm4OJ9pfIH9iCIxeoqnjUogjb4Ap+N5hhUdQf0qKnZ6hw7YOZueLhuUrMfKLSMunxMAremOYlxsl3XEZl3UotQRO0w+0fOk4C+dy9rAp1pGFFgZn5MZBNmHNdwR1nySzU0xCualzmCvggCbnNzA4Sg4I7lA+5GjGO00oqz1EAAVvzHbDRi9TAuwlWAfmHQXmdwfzGhFuV3vU7r7ig1tKKfbCVMOYae/BHE3MfKDcpip8R38OZd/oGWWGkA2wqFwEOoai6yy3rmXDT9unVAb9VLYB3Y+ioVbzMkefgGWMgvMCOfQJjv+lx2vZkAcEI1E0YUcy28xyuF0bWYWHaXcQMcTEVruXIB0ebiA1INWY2uKcTOZIKpRTFRxchXFTlMc2Vn8yhhLeDqPCuUxDBNMa8R6WILOsZgbb4lK4q5juxTDlBGCOffwTf9ChTDvhMacyrmJa0Qct3LuBf1KN3qVT/4V/mYEgwV5mOuRAgXkSklGDRFDKiF3cYnKb+BNgVV8oF4qJKanQXVzdl9nEo1fjvSo4rvcK3g8sayR7mfDf8AiJH2zLKoC9cxoxy6EwtrcEostMe4I0jcQlYyWUbgY80TVob3EbxqAvUCw229RBlniJd/DMJcGCKo7lkwZz+kkfMFmSunE4moSwEaI2uMkS1NW67qWuEhsn2jGRxmWYRQtMsYYYL0RDlLHpEXnczhX3mFgF9RZpu+CCXmF/iXCKhg3yl9d26gix0qJJtpvqGiAjuoMMcL1DQTEYipi1pyx8y4SwYQTMA643iHdDxGwtxJbrVTBpVxFWELzfx2jhncdvwqYs/Gv6Fkj0aMHZvMPBuPbhIlVfv1MAgk6uYtqM7hOg4rPMbBrad0xmozggN5Z4xMplj2YlhLGMrXDEWunUGpViemJIUpfhChQC7yLlhxnDW5cya44Szs+5m0rnEsMtQYIt+dS9gW4nPfMRlRZrxOx6gc+ZhcF4K+EoFsINzgg+zyBiAzsJYzcA8TUS13AA72R7jI5/4dqVL8h8A1nP8AQEgN6QO/wid4GLlsVYEwYhbERA6l9YOpRa4jE1bIN9kWsgHtbxOsDMOYLmUsoF04CDVN35l6nnI1cbPbaptqoJ0XKKsXMOu0uFKNdpLhTV56nURoJWuA+YTjiZDcFEp1KAv3KmyZXPDoLbNYFdDEvJymIl6bKzBgphJeE1uNdoHO5hyG5URSBsJWUmZFPwE5vwgljKp+N46foznB4xGKfDM03CFMxeWOUUS0sOrFh2K60dS4YzPEakwIvMzaxg+5WbE48TDGhyqOwHda/MOS1LuNhWB8KC8tRoqhKo0VNz9iMJGCXggMi2mIqPC99S/KmGHvFfwYCb3zLeB8Q0trQIErMvxKzA5A4yRQacMYEcfS2K7nYJRsRQJRMQHtrj4FsBFr8bf8AdfoLOAx9Vcco1rHRS1EwWC/uJYenxmC0XbndQs4rE05R41G1Z7qmLEbr9o6DAxWLl4F2GmcNyxpa6hdAe0wLHcGIWbAGW2YD6QwUdJiEHSYArbyhKmwybgGXSzwzKyju6xMz+UaOAKQ/wD5lH8z9nw5z3HcF9wWgOWZkWuGEuIeEwDIShXFjsLz+0bo1BZmO2FuL0ajaFqC34JsuJ+iXsKGp53A96lSduZcl+SEOcZgUcjdnEykm6lUNxokd7IiAFYy3A1Om4CmfFy1bFORnlmUpf3DTDwLGJVvSp6Yuk+pVStuobvUDPVtTPdJ5Z3i8RVWdFSwIfiK+c25ln3AOBHfpphXtVExZpLqDR0YuGpljmWGMTtvH4gXKGTfBFe+RmaI3bGlXYlybXQyhtXQkwoDbUeyv9pgB9ypRStziJiURzOYQ/RlUGE2j9hidllOFWuY0wW1NWpuVsG1OGo3LvY2+IAyuS+J5hdLL9St9o6hzC9pvCBnQOZs/Vr8Ck5HmGoXQJYa09GH2bMqQ2r0k5AuOa+pYCTkYl0K9KL76lkk3wQBNl6DzBZIuviXFM3DR8wGlGILgBbiFbW1nU2FkxmVutajdjwqp548ywMGJklaYzAVDTd4llu7lQuW6iGGWVmMKKLXEChmCZBlxhO/ghlmv6FQnM0Yp2nHwQkvhUAzRlbshB0OQmeTZm4wtSYlWWGXXG5YajMtefSJYu4EQrR76iO9kfhFIkLsgWnMPoB4iAjkmEvbs4lK0cqaQuqUVV29sui1gqAAKac36jqk0DxMo1TBbpzC+m+GWkvMcO4MHhKzEXTLVhwMfKY7PvSoYoDMW2xjkoxvKNN1KpPVhzSauoroguVxSG9RZbU7CNCbZwJzDAwjx+hYI3eb9RayxX1HXiDqZC8kpCZppq8waWJIsyXjEFuRDRCmZieOUcBTBqCWxiK6P3maX+Eq5Tq2W7EeFhMS9RbCuzFyvdHZBAS5vJKsOP2htGUyIMOO66gs+qxD9WMZdRLrM1/BMHK3jSwGsClEKevMtPQ3mqpLAFuiMxh7Rv8A5BBcR3HL4dKfMK68dwKDTiPfKWscsoGLmM4Wpc6jKgujlm6sNQYHxthzmcSoMJp+gqLLbeII0Gpdkeu1d3DuJeJc8MnlGwzDH0lczVKl1KTmI8RqYcGyKK6APohxv9/yitBReCJUsNfc2NeZexl1rmYK64jy4ztEnIxCm/2ZYQDNNJKURd3VM0IWm/PqWFwRpzcNKKGgYgYFbzPqpb5X1nUsRy3iklc8g8n1Czs94S9GMF5ZWqL6mdEtBHmcuSe4eMa/BsRJNPM3COKDuZOdq/qY2y3jqUYhQNVK0YOTMqyviFbmr4vGpWP0lf3xLbeGDmGDlpNkyGq1FZpVrQ58wu8Kqep7pcRjQGowvalKqw+5lAKeoL6188RlWzwKJbIRg4x0ypmO7iuoGNTNrU0GI14LhqIOE3db/Err0ocLX2XM9IFlSvyLCGiu26ztLGNeM6lIzOoez3XWFNLz5ZgCMDGpcB5Q1OEPFPLHtqduWFlVWbap8ouCU1iKodJR+Rl6jS9b2lhoUz0MUEvXmEzCO2CormduYEEZ2/RxtygTouVdGNFiqBxlUsxkalBabQgFtXMsCowQy2gr2uqhdgHBAEB8ze2GVqWlOMvmOlmG7A+4YKzgcozLQ4amNtgKLitCpr/8RQ2+6WEC28DP22EzZo5g2LzAyjGPcEIeDkIpuNRwa8ymoO7liuBcGqTwYkoZa8G4QomO5zBRkV3C1ZOFVFfAPcyV5nmRB/mdglPMyYZl9ig4LOYKj7zqVaJUZcsvcuWMO5eI8fpUk71f4ouFyB2Rmra4ysI7BctCz3KHgvWcwp8zpjthSRlhoOu0rWZnzlq984QncmokU9Y7ZTML23qdneWb1XxiW2C7+n+4s3erlzK9iVOyTv0mStnb+EMdlYlZVwGCAPkQYu7g3KAK0sZhb3OAGI5bwYmT2rZxD+BxBaBZsG4BrSWjGUGwe6l/lp1SYMex2bnkEQxW+YaDCM+YZNsobla1CPB83Hj9JVaU69lQWmPwSl4cMzKVtJj+3QXVw9W9Au5ZWfklkrHF1qBC3bUKlo7eiBsWN2avd8RUqnBmpgDOIN211JiAq+/qU2qNWEGVhWtYhdxNjLGgpkW9wVXqviPD9sa9SoG0ImagLvw9RGOhY1Hd43DVVOXP/SIk6s2P4l9pWVYhuow9y8rwqMiqHDmcFGlRhv1UxFG/GpeXG0alAP1GHDtUbDmCBE1EBdOpYPcue3ziV8cx5/TzGIF9MYRsudwKA/7wMibhM+x5TpHQShpdkxsrWWqjdU8ykW+MwhhMa78RuCjQH+CPYRrsIuKOJeILZj/4/EL+vywEjWwvmbiHKP4RLXoLh/kjKVUJlJVDK/MHCwGldRyKd0cTMK4cOoXzPMDI2zuWbQvGkPYDYP3hZ/xcoaqvDgId2w6ITxH+YBingHEyYOe4akPljBxxES+SwY8hL4GCHFmJ6eJRqVNwc5lwKI4I7/To4tbafvFIafc4xFSoNkNhXES6HyruZwd3Il8VpjF3AA9MVbR7gobVK4ayMsaU1zOJY1M7vttxLO0IUyaDk6gWf3xBg5seyodCnxBA1zB4Zk0l3xA6gMyYhfMdbtypGCIo5dYlGVXUYEPOBK/eeOUMDfxAjrOLmAIA3MXLI77JfT0S7hbQ2y6DHazCK9CDXuW7h3VLdxfg+Az8L9VxLZIUAhuJgwIFska1cKGBRfuUAuDBkq4aNzhorHlCx8c3PCPKW8L8jZCz2u84RlQ4D6iluVxcyt2yj6eGZ87u4LbVUXuJ2P8AylFO2rgkiFJo6blYbRYCb6IPjD4IbpLwIHuWsUDmPS4qlvvxMAvlUphAoyR8SjtSXDkZNxN8vYOds383GcfI+FRFt/VU2eZouXJhgXmOCMXqohVVh4jS2ii5VD7wddJZbEC9RpVGYO9uYIKtDTwxFfh4zL4CrF8wQTTSBdRjADOLjXcB4wWC5IjSd9/2jkA1DgSzqAQsIrasrlIAC3ncyp157VS6WBijuVVmoOcf3IWUnPRNC2DD6i0HwsYMlmnLG4dOYt2h+UfrFP5lgBaU5xHRRZ1OPOCWjAD/AIr5C4H9CMVvU5A4jFREop4lJy3rxAU1H7x85ySwyPoGEV7LB1cq934YoLB9EzUHczg9IHZQv2JwlBVwNWlxKl5U56iCx8y1nBvbmICGmVxnsxi3mK7NeBuIYYHfmWD3UVcLStu7jU55lbkesGXQyoleVA+D6XLnKgaH/aWWBWiJVaeG+ZgBdFqH5ha3lnLfwib/AOdB8VEW/wBdTEPAssMp4jRczmpiivTBcV1LFYg0QcKi1/wQMkUAmPV6mmGdJ+EwzRiuqlZYOPL1GqBlQwh3cKgOmVGgKBpg7Vp9Q549rDZH1YHeUzhLuomSHRyzUt1d6ZW7Kw8IajHBKmPtPCThgflHCG3HiIoRG6m9NrZ3LPEEWsMqFx3UGpeHMQijWo6M7WWpU3CnONSqbQTBVsEdf8AuUfDguXP9C2zEAU5Py8TtR/EJo0wDqKuMwUNx1PHMyobFOJWBTzDYixcSiHA8EAoc9DlScP8A25cgC81qcX+VLAvT3ET7GMnmA1BWd8xWmHhn+Y2LETV6ZVF397mcgDhpKyrY467l62HTqLbhW7ueSXNThQFVSazOUVWSmyQsQYBgbhAh7jWmOPEHHbzKxTMKWZDJMt9u5TYYiZitU/DC39OoYtdS1u+ECitbjfLphtXkgk0zKvBcJS4TcxVahySAJxzcqDae5mR73KNxWoOR7gqN0cXAhYNJ/wC1Epq3TLJw/iPHCpeJK4dJEqCsRRcCs1WoiQtREEQ1tMsIzgUdp3r+JbBf+ELbPV4iCZfUVt/UQqC4PlqDqjdcM1lYNQBzqAuDT4nd5+/gWZWJXzuf6MaYo5z/ADDCOezqDlV4mtWMp0nTezqUAdTUzQC4VqIYCfaXu4lqkFZAbvAtrUMm0MRnpvt4lLhU0u8ahYJbpxUt6q+ozNl6uA0IdVmXKHRWSVtlnjKUDIvzUsvI9TxItD6Sw/0ucISN4F4xKOryQYp/GJuXfqNrAFplvdMUmXMYwsKgBjUZgfDr4Vv+lRWS0Cy+m74mLZuKR3mXGtWVB4QNkqRY2Edq7NXXuACo1FFqmLA98zPZYMsALeJaZfUfZhdCEwJuVHtuYV3rqbhhEL9VwrssxmLlkkSXtMIFQGq6lmHMuaKjRxeyF5dPM1GmD3CuG5YfEu1DMqG4epZ/TorIGqj/ADMEXKFKgf3h2J2HMbb/ADIs8JqtTAaudxH6S7INMh9oGAvszGLVT/JOkeqynSMRbD0xyohPC/iFmypnmDcmO5nPn3OA19RcZ/mUMivM7UIj/MvonGZqYlXKN1e2UDu5YriYNcfFQSz4rP6kUcRmC0yi3gAT78kCU/zP9mpMplfHXqKtWm9iGoYuiiDxAPUwI59DMYH+E1A2GWYWX5PRiPiGE4dRQbL8RRrXmNEXfMowXXuKA/NOxA5Go4Z95atiVmlmBv6i3RuId7lm7/aa3Gcyu5xKSot/1jFOoweQUx9vYTfPDWoYYN5E6i/b3HG+yRMFP5QiFHhAKnpcPIMWl3CWtN+pXiDTKdC+qaqWXmUWxp08RgFXJEhwYo3BziEuuKODqPzx1UxYM+YgiLInCoxH/cUPMz+Gvmrf9chhh9oepiSLhgLNLwmpxI+moOV34hOhIaDA/iPkE4TZBWwHDuYZe1kRYWjfa783LLLG7iBKA9v+UyTNtnI41ctLa8bxG1ZiJ7O5Qzz6Z5S+JcemJ0h8DLPuURv/AGHU20DPSwrGSOlnwy1XsQxkE6gnEeoVxf0R6sOLhmU5IshOVMoRV5i5TMYzPwsR5S3T8BbdKMVBCdym2kFDARSgYj5fr4qtwfgu/wCyCmpu5UEp1FEV5UwjwPhjwIYGj1BZU12QFb2MwtsvK8TvvSflEg+EmSwZRSFlCakp3K8ysWvqYOYglku/7RdTlo/hT1P8+z/dTBYMGKOG4DiZDsSjxM8uEN0k3SkOdnqOyiHWTtEE5+Blf9uuBcwCa0PTBd29k+kr0SkQ/ALRiYU5Yplv7zf/AMEA6B5hc2EIRVjxrMSok98zYC8ZlhZqW4jeIMYvmaNarf3MuG6uDhiBiC2pC6t2v3loMm3Xj/caKMZzGKbRM0YXTKbR7It1r6gnFPA/8RvAHnXbE+hFmz/F5mKFrvVSwBv+2qu3/j5i3a/pmMnz/9oADAMBAAIAAwAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQz8ckoAAAAAAAAAAAAAAAAAAAAAAABC7inyhy2j4UgAAAAAAAAAAAAAAAAAShfWCsJgHPQ0eBoUgAAAAAAAAAAAAABw0s9sq9xuEu7R3WPJQIAAAAAAAAAAAAP8MGZfwHCXRc9lfS9W7q8AAAAAAAAABjUfqJ3JsX/wA9weOYyNpwyCiAAAAAAAAEjo0d5K10qWuKy0kfP2xICIYAAAAAAAAy/wAvrQ9w9KHWfcEnrfizrvmrQQAAAAABFU1KAFfMd/cv9QOHHwGSssg0IKgAAAANi7chsmYpPHEcaC8oIktvMI07uLQAAAANAy+8YGPZjjckbabbN445AXXcGqgAAAArFI2zQOZZnkSSHVwrPSNssV0q+BCgAANUUkpZra/c0t4ZikPafNc5ISPtfDiwAAKVNIn9vvQ2DXHtLFKfC6wbGF6uuPgwAAO0TessQh91r3yCx14Qa1iNUobImNjQAAKz9YTsDl1Nuy6CVbwnQXtuXY1HijowAAMlBq9eIPBrO9au2Us9JNuPw4ZzGEgwAAFHv4pFosijrWQMuf3ohFNn60b4OK4QAAAI56Rb81/n095pj3w2jqJL42bdouoAAAAKVK50gLfAf5pwXaoPCPMrY9wlFlwAAAALPArnztCdZI3NcW8DTo5Q8W/kB4gAAAAALEdAzSUy0MIU1W5bkB5TTVukYgAAAAAAEnTzkdqeihflMQdanAm0/YIKAgAAAAAAAKakqcucpN8QjT0Rz6x6e0UeAAAAAAAAAADq5gYivoR7pt48f/y3/wBNkAAAAAAAAAAACbzPDWfOE4Vv3rBGMGLEAAAAAAAAAAAAABSQBOoTlI73vOqnnOIAAAAAAAAAAAAAAAADtCnwTfjr14tQYAAAAAAAAAAAAAAAAAAAABBvC33oHKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYyjo83jMrDrHs4AAAAAAAAAAAAAAAAABz5yJ7576IKKKMD/xAAhEQEBAQACAgMBAQEBAAAAAAABABEQISAxMEFRQFBhcf/aAAgBAwEBPxD/ADdtLS23+lBb4bbwc7b/ACCSr7uvrh0wFjht8d/gXL8uDq98HbHjbZsi3wH5lyZdQCJ0hOHbuzh+EfjXOJsdd2BqzO1pAPp588EggJuWWfNt1HbBa6WP3KbFYR3U/wDAsZepDdZ4LOUJ5PhX0XePcWVgCCPtJ6fUbEQstssiZZLkY+pmOT4ArOkyT3ib2n0MA0tc4xZ+yFiXYjkpbku878K6yAF3sExu4gRLXZx4XLdky9pMstgWks+P3yeR3/5vrbV7ukMxJ72LNh71obayyT7k1sFiQrZfn9Wd5ZfZJC3pxVdJCYI6b/za9Mp4f4fTi6M6us4ZIs9sHuOxDhfiJ98JddLHcnD+ynotfc8h4njDhdsXtAOE30v3YPc/rPuQTA5QncdnGy86bnCeR4i+rcdITLvIr9Suz5Lha+GN23vzPE3gaN+kPdgvdj1C+/A49R6vfiW55Hh2ITMlsndsbDWBgx+kR5a9IMPkPF6xYOT2bHrJANLp3KWvB5Z5LIR8jxGTN7s+rGRYZyWFvjvhnOY/GdNif2/6lXgmGD+E8k2DHLL0WT/zwG3+cfZezSDhjg4LeN+MPiO2PqYJbtg046tttt+Ig+MEh+mFnII5Pj35AbU6bptSzZEhvqPkD5Qfcr2szstiYNiW287HkH8D+ZODhpZ+WcEeGfxoM/mZnOrpsssss/nwsWebLP8ABxYsWLSxwxYsWlj/AAv/xAAnEQEBAQACAgICAgEFAQAAAAABABEhMRBBIFEwYUBxsVCBkaHw8f/aAAgBAgEBPxD/AE0Tfo8lr+UwHbB9FmWCcXE4eEJMr+JzMcMa3sX9tglN6LpDbbb4/ufp/ARYQ8u0F+hZsErbFtvjbbfG+BnUmfld4XNu5Ule2V87bbb43ydfDgSZ+NFhDxcsc5ZbwXPw5tHEss7+G2GGWJtvncnGTPxMcu2yQJKI4IDvzPI9mOhD16y8XiI3bmB9+GPHULb4IafhBegsD0g453EoQsF1LYFcyupWQ/cHbktkwrfK8cMfUPN7vwLA/wC9mD/dq/S+hH+l4tdx4wxtuA7v1I24s+ot2Hjcs9xdyZ8hdvRzbNSeluHm/wB0toYU4erfVmmzxGocXqmhENhiZdW+F68n38uQ+4tlDzbH22Q5YYvaH+bDQ5jqB7kDqOGQTmT7kJas8r4PhGnxLi+guAy3aIp6nzYMrjwmA6+25J32MDZTnUAW39Rb8DnqMHwTH4DEkwEvMQ7nd/1XJmhe5G9X1YMoMZTASkjMhSVyF7bUjHhs8wmoE3vwXf4HTcluHx8GwNsxRE4INuL/AKZbDIFoziwS+nKA69+NiBRYbN2ETSb34Pj65ORDTwZKjxc193Zew+OeGcjlmtg3CNDu3x1sjXZ43zMx8rwXMp3dPIbC6XPp3AwGTJkjxHDc7biIBe/Djq6NvyQAYTMfKsDcpMOXq4T1LjiBw6/zM+FJc8WObDXmPV6lbGWMj4eeICaeFEW3f4DjYCGm2ZxbMbfudM6hHq8kE8uknuW8SBmZOQuErJ4SbyRgxuAjLJd8Fl2+P9chaSV5lygHGdeFxOmMmcyCTGw9SQ/ccW7dEuwZelYcNyLVnNk8Hy5F7jy3TCyP3B7ukPV605ZaJ9kjeJTL9y+rPaHbIwSGc2lvqxIfL9fJFpCZnknTO8Pczz4ZjxMavokOdv7u1ifpI9wJCOvCWHjq3Za/M/0MMcYvZLltJufSOtOpPq59x/cLtmDOZiZLmR4n9x4Z8LPB+AcdLlTsnqedlh7kYJGu4bCxYSfVks6tFkIYd5mWXbqXX8L6EVaRlbDndMSEzsSWz4NPGE3Mtl1slv40X6hBY8w21bllZHvSWhnZ+OTMy2Wn5XNLlTu5o2JUcJ5Ioh+CTzttuzx3afnRaRcLtepPuQ3tLZwJE5Ok+FtknUu/wukb0QXpkwkg9w+rHwMa1V/jhdMH4NS5Vr/QA1wuHb+v/khev8ni6C4d4/58wn/nYX/7D367P4r8H5bx4//EACwQAQACAgICAQMEAgMBAQEAAAEAESExQVFhcYGRobHB0eHwMPEQQFAgYHD/2gAIAQEAAT8Q/wD4xn/6qV/69LxB9Kcsg/EP+LoiMR4ifEQ4lf8AoVNyMoVKhoGO8CIhT4Wwcz4X7wYq3pW/oECqiacXU5blWofczOL1XhcsheriN0EVkh6TwHrEpNBLKkfZO/eo/SI+Ylx/xX/kq0FYpkQmfE8RG5VG0QIQUBuXv3bMLc4cPvF7M3VZEVy4RUD6ym4WmnR7jC0bcj51KlPwrT4xBbkpvA+IJaRhHIRdvq3QhQWfm0qYEvbUGUPtuCUptXczi6/EwYU9CyCQ2dxkyPsY66eoo2f+MrQVgC1niJIlzew8EPnDisPNR+YuAxCsDHLHqXBReAD9YdnICH5rMvrgNsLwcwqrT5kHZNmlv4gocYAiiEhVN9sOO1KpePVO5Y/iAqaseiIRi8MQTqOacMIoF55JjY0umZyGS6qPKIdYqUhD4WELUfj/AIHGPvKoqz/4QXAWkV8VfKX9DmUtQ8Vl4NRh3b2teYOGEsNP5lwfVRsPrFTJMBB6tyfSpYHYLrjr4me3cKh3zqJbXBeXLmphKpV0LfjiO9gGbfTuFwLFlGKhBefUXco0F37j52xoXPMv7PoIqXuhOH5giKp0kqqXwgZW8m96hhNHC48Wt94FzkdKiGkPWoNktHLwnZOjiCmouhETf/fPIWXQ6BBZQ81U/eWja3Xfi5VDbdKb6lrMbh5+Y2MNgXwf6l3Y2uePBAykXTzXUqCQ1abrkzccqAaTdvMHomGDTxKk2IsCeH7wCy8Cu17vqIcgGA17fmBaMghu4Wm+3Ma5kCAXjTq6juxFj2OeoiMZQcPUsIrzgoZ/iTGClqOuWDcQH4myGnLcaww9MAtOeSVQSnuGuh7jbnJALGfENyRn/wB0UOO4tDspPHx3Fkzb+qCWYF5ayHQce4lDHCtv8R3UFiGbJZLqcuKmctm0NjG9noGKRapYx3cdQcRYb5YGRrYEP0NxZVBmzqC7RQuJ8ktDO1N+xiAKDBjpXNQiS2LBIqytU32+olQQKzGLRu+vbFN5sDZXrxEBmiV0XN8JGSDjaZsMGZVayL0Nm4+QTjiaa45IFk3vLLrvwdyiXNdcR0FeFlG7PtKNPqC53EmgYi1/2yWHyiWWGf5QwTShofgOPiVi693V0e9samBKYf73E2OVhqMXEsl1HBIrOf7UPvYt72EHd1APgIYC4p3O2Mv0hW1Jgpjm73B4vm6uPVTJ1ldNL4JhTl0Y8in838QfLzpl+INGcwwunywuFbGgV5sJs8HKYH8ReAW7XZj5UChePmWogtbqjs95xBXkK0LQ6TjjiJW9KMTCBVA83FRdWq9RyAogpRMdzY1KSi7sclSgNNY2NO/pALIXeP4lB0rFRemxxMV1At+ImZg1t3FMkT/sC1GVs3pYVn3EVnNdMsUucFTFkRjA6FfFcEALXwYF9XBlFcnUSxTSu4wLh4uoKQv57cYz7gKCx4M+a2eI3VqDSeivzEM3vJAax+svWLhSpfcRUg5iQzHAVoitInzxNwPCLQVTlqWsmKifISr2Ck6vmAFEVu1Ll0Ghta5mPkUTfmVZEApkvliXEbsVidZ+l4ly5bLLXqGBeCrr7bhUAFLL3ENWVdLKIpf39zPJu7y+8YvHFXVkuYLGPFU8y107OYbH+pXozErH/WLY8mOE/Ia/mKGRbKyhuN5ZN78Sy4WrWsucRQC9fzFasCUXmtK5gFANbHoc/aoqu5o4gYdGcf2efEMwrZtT7NERADdgef6QxpVtWfdC2ljFubf0lsrStHDxLIIDB6joUDBVg+oG2myCpA81lisEqWmOokzk1UeG04DL2sVcIVlrtviGQAugfJ3GoFoGe13mKEW6Vf2RAbNJV06HfzHJ1oVAvfMfAqcZyRqo3X3hwALb9kwN1OuP4n1A31BCuWT9poY8nUteIJ8xC8JzKUcfiMZ/6oVKcw2wZsm4AybAbeZd9QIOB1+JpPAS4ZqkqVnRFBBQxgHvxxMVQwgo5go1hVQ6CEc2Fhj2jtl6wy/b+IUGBbTlXb3FTNXYHGIaAqrLqKsrGboB/wBRuhYClOPccFN6HiFd6CnJEsNXizJMvndVAqs33EWAzB2cPmXpWzLepiXvAHcpwV5H8ysWUAG/MEeEtU+ItnMtrfECBjLYahEEoKuhvEGozLSx3RriM87aGxOyLAapRCrTycxEgOQYneW3iobFUxfcBwMVrMkKF9zjX+0DDzxHTH/TEq1ZoArfBEDx0Z/YTKkYjlYv1qvrZiGxoF4A2wTyUbPwluFsBuvMaJa5Kx1DCC2tAA7XQe5okgtRe1qpUNdjkxDkSzbRFOlKCgN1HKBSqgdF8zNWKAzwQypCVpX6GX4ipukskKc717ghoTYMxpCBgGEosMdahMKao5ZmI2trCVA5ckmrdVLmJfumNNYBNNfvGomYJQeDqDdDReJQVHijZ+8YDHkV5v4hsYmoqXPX3mT0UKs5OuYfQQgJ+8OKuCqY4lgIh3lYbOC8QBmtfaKna3fUMC1BuNGEhxKoVFbNRwqrh+0bV/0Qtll1AEc+0umQo1xdR0frHdIkx1WfzKvKXwXojPvFwE5gSSOC7/KbwYbRwfHcbqIvQIeFXbi+3V+4xRcRaxRjN5jSbHOyFRQtfvogMiAw2kM0HSk+6hlrqMhmpU0KrVgSr/JCkRysVbKUNeGYrBbwGY4JHktnkYuOBdVlRlxQFdPiypYb8sacckJx4pWx6YFEDLCNCnJS+4FRLiv11CsBVqsH13HKkma/oqPYH5EwzJ+HB18zEKcc23GFHGsOIVf0EjNVm8kocjHEJcUNtPEUFmL1HaYvMFZIvLFZIm8wWE05GDX3Fyv+hgbBzGGRyeGuFlff4cngHluLUklHg5hPzwB0dEec/UiYzLgK3R3qOWwZKdJ47QrPxD3GSxhqjCND6mvtCN0Y20mWjvMJs9o6TMSJB0LePiVJE7CwShjLqaD6Qsyw3A8/mUGRoclQr8STDxQ33MfiFjavljBNQqtV7+sO1JsAl4uWwKfKDd9vRLMCCCnWrC/zMhIqJf1YbiV2l3GgGHbUPFo6Yb5jbKKbqt+iXLg8oUEZFlWsBGtp284IiKmeNRbQoOIqDjsm+5cD+srot7OSGpV0xMo26lBxRANcwC0lLOVhVJqozWIpS+pYTcJLP86iNrDdrm76+X4uUQKAdcRgcn+7gjggCkC8XzBDdqtruJOqt+n0xuK0dXR36lNFlrNsE2Z6KjGhRwUXH3xAoDVGwWtccvzLJXiNWH8QBa7aII4bJ3UezKGxw7hDdTdpbG4G3kMxbXFS7DNvE571Eqlyh1CNu0FXL8xOimLb88EvgZqF2q1xX+4BgiZYO8vxFyrYsAOYbMTlEYw4imBFjV4hgXAuUFFZjguaZQQa9wcmjC7zFddAue/mZMpHlgSILsMVMY1myLLco+GNcF3xFVKzN8MyxduCKAGcQgDZhGAmYmlg1l3GacRMeJrP8yG0g4xLXB/WeiFegkF7qAhVSkVypBJSNjLRADwRCA3moOYCsaVm08PiDSAFhYc5339YLcrKf14gbO35zAtNyLnLuFfNDXJqMSlPRGSCoVqDm+JSht6nwUaJRCODWHdwZQc+endm4XFhiumW4tu3CQiIDNTXmuZTkS2jQcfX6zKWJlUK7Xp/mXwpcqmtpGt+LjRm1oRruF4aiMDz6gqm54IzNSOHaRkYTWzf+4V7KnFi84uUoBu2AdfMdNIYHMsoLdu4vQVzzfqFcMuG2/kjyPjUZzOx16/iBDvKVpHBaVMZ5qzbKWq3kOpYLvVk0DvcDyEBzOC4BSwb8yjHDLHuJX+RQG1gPHD88P3+J9gl8EBWmsTFuiWSyj6H4lw3LQWj/uDTSAu6RphVKBlVghjDqX5Cz4x38zimRRLECtaYFVCAzhF+nfqGoVbMoJwXlUduJkUj1n3MAVslstOptdGosAXJS2KDQ4AFniNuShywpBHsiRXQ7e5a0G615vH96g0ve6NArx/EyD6plDlV23UrSgY20x1YbWsoFcxSs0/xqVVJugMd3mVTtO8e4Yd+RmlObfmASiirCqfcQC+vlVnnjVxYCjgui4yPHVTBUp4P6RxsbrEHu1cYmuNvmJBhYFNNwl4y+JUNcQ5YUweIuBjOcw56DNbxcyh1Hc2zDIsyn+MxFVVpAnoqfej6SjRYHULYYb6MbbLDfQfWcF6MzQFxr4w1ExtAj0L59R3Q5HV4xAxZFR74+IKiCHMqbw8sRkMAFHnXdzAGDBNZjRmmxOSLTpdFZ7llNNBX9IrYUBD+qCLnZRncYFDgP3ju22S6YnyyuEWqzYQ57l0meWXitfP95SoK7dw5Gzcw9lMhCnXM6vQHDLNrmqeu4QAUK6DR+KzGA3l4l7+YgqKpdlGeqgF2UFoKnf4gXqEbRO4RsVAy9Cf3uWW7iERzfqNk4G7i+uZfbdFhsyVjfM0QGrdX6hg/LAF4vHJA6lDiZgLO1XGJwPEe6dY8y1rWl61LXNoKaiEOGs/8DFhnuT/GFsyUfAWX9vmVhQ3R1FXI42+YiBTP8rMk4SgAcRJoGe5jvSdcQzxSECwKVwXyH93LWy2eUoD5IA5u5U0Wi/iKNGjUCeu9SlaYHlLoUKhlCEpd0mT7wrpG26m/7mFTBDHmJi6IA8v9qDCdZWyygQChRqIInI5VC0LFtY6u/qEC7YOSMQgrgD0QQjN0bOg4nb5oLQJ9eV2nNX+Jbq44N+fMspn2r5uUjHumIK47jZttmkb+ZeIsVWqFj4+8Jrxs4FuL5Guu47lK0Cq+kxlThnAiLa2/MVcOB/ELLdZ8zSjdDFTanHcuCgG64iZpsIQcHyNztcOn/htVhqG5qZWqWJ/iUTlmLiz9d/SGJtAfMpG9SuoeDblXcEUtWfExQQ4HCX1T+/EF+oHw2b9mO/EuHNLn27YyiRWoB5xxCBXOoBi1Oov3wQKbRNeOe4q1Auwwc/EKHZgx135/1KmhSrcP2m8M1l0iJJfQO15+sOEseV/rLSE42WMFSCjlbApCvFVmuYKi6pVYDMLBHTMbTOB3cbBxh4X1BqDwqQDCVxsNZ7eYPjSjJV/37x6UXFSrdx6Fgxe8eMZ6+stbwmGW0JQaUwtnFaxcakBA8kO2yv1lI0ADRUMRhz8zZjRdRt+xFvGuMwFHSnJl5a2kotysP93HKLypNVM6ddxrJWNtQcaoiGhxCjsJSo08MRGnZMwCXfRKW/8AFUMxBYUijyy/dZQwyuIGZgr3HLZlaBhlsuS2fUUhXdwUjYmDESzAIvtMP8gTwh/MUagOclHMYUhc0bPMGDyL9RJkF03DfU0uC+3wxMxR1iXcRAgV9GTP0hlP4lm+niNmjdS748eYUrNVWx4qFhScy/8AURGDy0lrncaAhu7i1h/WLbWLN4riK1xQLI8FwmLBVi19s2GD0anJWtcieIKprBfxxMaAOgruU40MPDzC7JGiOH+kAqRvAX57DfHMKGg2Lui/xnxCGLGOS3jxEyohF57WDcQbq5jRWjbjEDKGVOoqAAHJxKA7nYhYBU1Zj/RK1otLLDXHuPF4D2O5dgIdLHQ3rjmC21nmGafM2GHqLbKTy4lLZYzIPqW2mnMf8OdQD4Mv2iAspIlrhrB7lx6LjcatBf0gijgX5mOAWwRVP2HWm2AjFWGG3Pq/tChfgUz7Vb9YgdjgtnNBBTh0+JYJwqZgfC5us180nzMdDksKdHH+ozAhWEZUDK3u1tDxuvcYZpDgpheTuXOzUID6kKVYm7cRSQxWWNwYRuKbNxNCK7Uuf0ggEtqnuHZsho7lFVjwxwUCvCJvoLSbr6RQA0A8P2hZIDZRXxKuacoU6QFLQX95Q15Ja60aZVXPzt/3BExeacRFopgPgFBatD7G3acscF0m1HGcwozYHGmf4uXIh0YM65jQLXkc4mJXmnT/ALgAAVXkmS6zqMW7IALbYR2b7ipTJMY7bIEQlMNyuDj+/tDTP8BpO2OB+gV/a4IpWQ9xsRH7a9qytoRuxSPa/pOUYaKjDDbF7fbBO6Mpqy2fJZ7YgnD31YfqSphtYZSCl5M3wfpHM6vEoxGuc2+CObHMxd9xg5FcFcVLR0ogHhTN1HAUoy0DofZc3JNC1Pp0wrCbTQwfKF7XcAg41ZtwKnbeni8NXcMDgTYfpKjAdG8+JlMhKsaMn+5QgBsXSBDGsV9Za2s3go1z3KeUM/yjFScg5o8dSw6Bh1C9B3iMqLG8bmlk3Vy7zbnB4SnQMS3yJeXsrHHmJcEcVzGsgdrtT3CRUYayRCKc6E3/AG5Y5K2OfcASAlSNPdwgtYrBFMrHhTN8EupmJAEpuKtukC3ETkhr/wC3E8yMuGionov9Zg0rkO4oQFY0WwgoFYSZlPZGYHFL88wDbk5a/EpRhApa30/rEszVcARZ9ar5gyhyI8pmNaMAPzEC3sYI2r4uLH3lo8RzUp5mfjjLEayG6TT8MG/z3rKckXDHDuocDXSbYQ2ptQPKcxmGifA8HccE1iqgV/qGd0coceo25vLUvpLQVObKa7iOlsWceC9xG68lA9LZWrM1wPSR7eUqHH1GCnZr9ZeVjxY7ZSh02JQvcdF0SDKgaPrAxBgypHhuEKRrFVTCJs3WLgpWzbzcFTRbhzKqua+JUOpQeTG3qIhR2Zt4+J8gSoqqVvmG76hFBcYzMxrxCGYrhniDGzUxUvDiHX+CpeZgYtX61+hDN0gDt1LpdnES4uNkrFz4mLk1mU1a7qvMVRQ9wl1M0tsGjy1EfIgVL9vYKfnEVBKWvHMYUYIRV/SBCx1G0Ay5ZdS8dkNqpZuGlr5PhR8ZvyRTQqmFqLtYSmadWCZbyjYt/wBr6xxGV21rYOYVCg0050MuL3UpjnKsMSA1OBnwzb72GPiO53bi8o+o9OqrRGAqANCNynQ0/eWlRaE38xxJNHXqVYbG++vpAm8K0YPccVRzvnp8QMtUC8fzLoDbJymSA4HBBz0C+JnQWtbjligKM7TfzOxioYKbze42lmmAEXwS2vBLwzDcGhcS6xqUr8Q3/g1T1GMHDfK3M5hCvjn9JzIkqXc5DYPMrhNi/oQFHWZYthbChMqVVxi6s84zCHn0ZAcj5iwLblPW4z8zMLCJ1W4IuT0TnY+81rpZZ7glLcTcghMnDK+ovSJxwJaEL7uXDHoCZzONrQ2BrMCuAFoesfL+zFttNCF0zjzjcYqjklWNBeqx3BVNBVjWIsaaPO4rOuOFf68/WAeRbSy7riVV4m6rjxBVYSuFfWOD9JiNIsULun+4i0BFpSp5cdy3UmwUCeoBYvAQ2oGVrLxZNg0UgfeoVVo5zcRlCOVKiwCaAu8yv4AgtkPMGFeASvvDlS2xv5l8Ticy6dIZiFFCLiK7OJVmxUOB5/wWJgntKeMEwnlBYaMo5cDHoICUVT7iXpYVUtWQU0zUYbW/iCKWUDapj8SuyDhTt4L93EHkzZFv4aX5goI2MX9AJQ7fqMTYrUeqCVbolSDcc68sYCUL/QczmwVexrdN4L+sU1dqKvlmeXkuPKQHuGhScAXB2qlfwdSqzuNC/EUhMgNH884CPFlYDLHNqb+YKxl5ClwASlTQZ2JFWAicLUWiMrw8zPD6U1K/ZALgvqFY8roo6rj3H7LgBlMNazk5i1zKtjS1uX0rzMkPErzDpdx8pVFgGheLxMoBtW6IPSiY9xJvmSP98TGXfON8xTdAmRqoeUUNQB7mcafc7/4R1BzwFkLS3RcFLNxeiDFkeIvZGIpyXHf/AN3QyQy64xMirQ/D9P2jEmLj3cLmWoHnv4xEGwArOFhFzqQ0Ryiykox6h7zvVVqphzCzys6hLoNGqIka4xtKACgfmUAVdSyFqAFgfR3HRG4Cj0239YoBDrdJTXUzA7T/AFAFbaAu4eKx5INiw33LIUNXLm78zwWMNWRu6QsrDvN4xnzDSGwmisVzWqlvAULuM1rcXigbLT1+UAMftVhbVytCu1ZpqZe7ALF37j2Alrxnx3NaBkvcdkHHAZ3b3BQLv3KiuJHR8MdN4I2dLgUJ48/zK4pn6esR2s4xRCbMoC/ayMBaboN9SsFoLe7lqoJ73Fys8g7jdZthrxHCzdtE0rFauXPBcxYygjm/+HQn2Yxl3/8AdEHPVcHBMRldHhw7+8ZGm007rmOoECqyLwkPMjSBy5X9ICAeLDhfnzGC0OuI9aRz4b6lrbKWIGfcRqbEt4vKd1cK4VVOeB9oUAUh2XBasszEoS3BdUGtSiwHyOCCoIWAXc1EgbsfggJXbmhup9uUJ74mISbZhxQGDDSxoFsgoTqxI+XqoKAVeRl5p0xamKZkrinFROtYdSxxdOFPfxBDU6CssrAtYABurtUYlAGrLv4lGQgFF8YVvMdIRzz5Liri4oODDmW3lxhOhyZCAHQ8kQoUpPtULXGd2j4gezGt0Qi+rzZdeZYbMK7gkWQAWoqKBwWrpIHShvMcTk/W4bqzUQKa4WMTQKnqIAO3jqFaaiTlAU6NSr6o7/8At0yW6i0cqpf0hERWpzlZm8lgGmrgKHYofTHcTAliuLzBk2G3RQNXB2KBZis/tHST5Ja7hAGC6cAbE8sFcDQsv65hJaznXLeeL7iaoFj4Fy67iBvMF09ZYl4NgKU1uZ52MibULHBzHvKL1GKuxumV+DDQR0lNMS14QEv0Qwm4GzEIDiWVBK69fZIJDLewGKDruDAbqqFd4Oy46uDy1ylVh1iC68gQytYg30M7rXXcLOZBcPcakNHmoioDqMWVAUt3jX97gMgHUM3lSgQ6wUbzCaeTED5efUdkIKi9+PcBojKoXffOvpNg4yAfWMK5Jz6/vUSRHdEb7f0IUiyo4IaO/wCZg0ZF6URgFYRC/HuUn3KsTPK31OUUsG91GWCtcR3ruXvHEaFPLf2lgnuO/wD7wksPtp+Z+GWmpgOyApCWpTEwAtTD819oFRorrjJmNeKp2C9+oMz0O42M4hOIS7VukzL2lAqKvIYjpcgi1nv31B1QF1gmUvtbB01W2SvkB8q0e38xEluDa/qxBVGPcR9k2I2r+kdhM+4bk/ZuVzoNJrN58xoqqKv+paa5kNwYgpTeThpmN2x2KNZvHHGoUWYJ0snJ2zJ4Q1N52wKhHaB1g5uKR9u36tb/AGhTlNyNxUc0zL5i+CcQfZvXoIO1aYizGYuYOCWj48S0BMrKoZaUTTBjuW/GtD4/hiKRVQrUNj01oS+1doHbQcS40Nxcs0lS4qUbqtG6l7qVc+4pgporrxKMFBtdssrtx3HKM1bECqjZVk4hZc1frE2u7mA5x/g3XcNnWSJvZ+8ONAYG7n1crApyrZNLzLFOIq7a163C3QcxQDFeeI44pBW/MRVoIaq68Rx0tV3iZCXwtgW+Nf6lQbAVy/EBmYKdZTkeA8RQCtV50vQ38+JhUWkTI/8ACrhVXj9o8tA6rqNIpGtTtVFxqmtotxWSUhzLoMKiyrni41+1NgeMpesjMl4qp4AwudxvTAGB8dRKUwkKVs+dV85lAA8V7CuLq9RaaqaGMcXE+5bYnYvuW1Jspl/kgoIzOwYQr3fP5q5Cra28Ln7xE5bOkXlPHmKdKrR/wfYIrcq2NfQ0w8AQ2VGf1+sHigVZf2gAoWwyHoiCKlJi8QoyVN5awDzErSu6xDciOe6MCVXo4iOQ9EAycLoICxY3hGWAg+o5QbKxKXyG2AHYmarZU33LPh/9s9xS1sqZeD+qS6i9Ku7KP5IRLXs4y/OpvkVZ+kBQuj4KNSj6hd7OMfaGjY7wFlf33GwGQWYSiq8ZqDrREdPUOYrDNwpBIHCG68eowvSjjb+1QCF4h2rR7YmfCt5W8q/WBttzeYO1F1KFL0dy8Krac8/x9Ym1nVuo2RO3MQA5hlel4+8U4jOivvHAOqLX4pPvCPcmSmnHN3DJ+0cjx7qv4hemsZRbLggIJivoy483F3TYsMXVP5jX8Qpc6e24tGwSjV1ClhnkMi7MRmACKrIHx4h5LBajxPQp9YBfDGWvm8Qa2sQ+6HW5U9BqlVdXHAKtYOVqvEVoFtCmh8FLAgsdjNxSQVHDrcvwYu1+j4l3rzA3uIawSJnJcqK0c0ajtqq/WLW7qXRFqomG1w2qqjDW2AAp85mYGPUu1Yx1H7IJpesyy0WH+Dw8yqK6XMFq5e+fvcpAaK96YSqZhkZ6fpHHEATviIZZali3Z3VfQhrBrTRgtP3hZivR28feIaAA0q/MfTo1XUU3dBsz/dR7dCRUEy3eitzMLLHk0oeOjqHeAsl0XgibWXGRoHllmJap26hWMG7ZYH5SlBugh39IwYYyTnIhXEWTwYFXmnHi5c0QrOkhcLQVPsC0FXzLo/VcMO2W61uuIwDaARfI9eZbhwK6rm7PpBUCURwvYXb3dQCmCCI1NPD9bi8wLSIHd3l7lEQm+6M4oF+yNd5WFsYwpLfSp2opbfvCJIW2Wdf3uKbGBLhylh4hBVG2IbrH8Zi1ChmWLXZuEhGqu6nh19ZRplUDDufPqhuYcBTCVZ+0BsLVLMJeZfwwE3t945UWO8QrbDVzmFVpKuKq6GYLA1nJFTkeoqUZWEqC2VVHbzNlUhS7FaH+AablouT9XH3qNyzOfP8AqI0M1iBW1hvjj9ftARLODYuEmeWKZGObPxUtyaW7y/twoPegr8vuz4lG1bTDXTzDzbaXRWiD6g5Vkb0GmhHC76YrC17dga+0KbP4giJYAFw3NkhhqEi8B0zZoUgDj9ZcUcULthnn3BXPDcHy39oEsXAF+XEVqByspB67KDa+r2wwBpIC43VY2dwrZXHLrt3Uyp/J4dHhuo5V4CKjzCywVeJZ1XU3QjlYy6m5MNWtcfpFKWlUiOhNyobEnDnL4qAhaoQV1bj5hlo1DX1J9IEGl015rNv4mc8ltMt7riNjCMHTBGLOnUrhlkFQ4dwNQclfl8xo6ozgrmHxKJ4KDLGorBX3YxZhpsigxBpzqNsatwEInczFHxDQfQh3f0EyWjF7jBdx2/8AC6GiNk1FDU4eT6kQ2BrEpXYPJySlTBQ1fRLlftnIxArnyHuFU6g7q8X8BDKFBqphU22cnETcq4ih0fSKEia2FaM8ZmZ/hI3947WUZjFEq0N/pDMjCysrrzNTm9Dd6JvXgiOQNxXhZqOmqpsqMpABwUDcLq3N36jVPFgJXJhiOSXTh99qXm02weeYiqyUp1fTz947tRnS3imNWHgAorV1A+tUbv57hka1meg4g21+5gRMGHwvp4ZgrgzoPu4eCr45xvMzUiw3Og4hQkIRJmvvLutpcgDwfvuEPDE2ezxC1pdjJBCorQEQpNgKD+vMYqmwwCnPt+dEWgVa+JSwDrGpQhYUHEGlPENCHEP1xUyWXz5jKl1zLrOUNjmfEajoUZICp3NaLa/4UbdC1LDhaPD/ADcdCVXEoQm8/MYUJYvt+ssjZF7yd/EakU4UcsTqig1m757xUpxvUBqJUkqFpbX1G4IO5ehfN/NS7TuPcRL9yDUsNg1EonBvTPrX3lURu3Q4zmJ8LW0ij6zSR18K3f08y60woh+TiU0pajJ7aIlxjmwiI2qULvWaP0S6V8CvguvvBGgdjkFzqJubq4MUj1241aORGr98RgKuTtfr+YVzCq2/H9YroTKK+24e2rgI7V0fxAhVFIV8v5lksylV9kdtvtanrmp3uytAdsBkq0hjY3DFsG0HyxAxcpWsyuGOQp+GLjyeyoQIi2pz58Z8TXNiAWvdb7qML9d/tALUGFLqK2IVhi5V2uD25ZZcUYKJTaVu4QHfcVudXEU/8LwSyfiVU/xKQ4YDmF39PvUBDXJ6juk3ENVm4ljkBfswoUWPiY1uzeG9VLNj4GQoufQ+4aJkAFg2Xr+1EWG2rtOaslvFC1HgvX4mMKt015ir1xzt9xxhFs4pk0cvm9cxfZHDrjUChRxKrqW3OFlNByPDnvMfbOKLQzZ01ZmUY4EyL8NPvMT4WYxGsJfP1mBnW1wZu4bc9lBpbU1F0mBy46h4JewWikdhaCWcnjhj4oqsFHgomOCHQFI3MUV8RYQ4BfML2K0j2L1QgF0SWSMOH0JXb4gX+ez2jhVtAt1gikLWqt/SKZw2tPleZbGSGwB4jIbYahD7wtZByYHLzDS74Bz6Kv8AmKA2IXtRzQy915ESIXb1GxY09EUAyrQJYxWJY0iNXu/UbSkhSyr8wAeepWDl5gO3Eup/jsErqZjGk+mDxKXlxeiIVwwPES5UwIQ4Ki396A8sVeRgGq1Sn6eZg8kByHHn9or+BXJOaznPV5uIu4oY8f38RL2AYYIROEHz8Zfv1Eeg2FlCGjd9eY1sJ3L/AGHMPnGlidzNDixQ5w34B8TuLrAqVik5vlhI9E8wMrfEIQENHAKA4RcS25hZiNR1UMDkWjb9VMkDuS9au9biAChgBv8ASCdLMALeIs7Wkht2iWFKT6VF3CJYBz+NRmrVQEHFvucZix29nUFk4Zpoe+fiDbpqOxChlQYEGDXEAqTVoZHD6lbW5FQvHmX9sqr8CX41dUQGHavC9wwrq2q+6iODAK5O8xplOarimjPVblhVljKG7rXaxyykoyDW8yzRXqKb7YFj1Fa8sVp/xqM8wzAmI+z9vmM3WplDQsjhIzXPcq/khwwSRjcS9J47iQ6XLAVArO4urzV6i4GoNRbhJZmbl8ZxUVSNhB5LK6depkyq8vu78fpNEDC3197iCMUhnzDZBfNam0vhkrVHxdPxLMILBumtePUfTBgKDSh0vZ3ByVC72dB9EbFgVXFftAqTBUDk1u9wc1S3DcmTiZawF8WPvojRoeDjiIhu45NGbxLwUAyeTG40jrTArxriFMxYAbv1NRqks+fXUoRRo2u6SJaK2w0QxNpTza7i6lLqx34ixBAgZrt8xeUGTlbAssOXcvnUWY4zEdMOgjx9eIR0W3ATMeGvEp2zuyaS7cygAaeYncW4LaqWfMdFkQRucJ/j3/xcgLYxb5S0/MAwyaiqQu9wM3TIn0hXQLVdu+PTEKk0LITWya1btL+cTC5iTLZvWsx0E0Cy07N158TPU4BVn7xldaUDS/d+IqWxwAH6VdXMrDabBvwn3ihpqiInI9HcHYxDuk8S+g1OCBEWsJgDOuYu6oUVVBXxDiI3ayL5zrjMf4EG7bdB3uMmmCnOtlt1CQ9i7F6p3sgs1oXwMVfEPrFyUDHNQ8VA9zwzQaHJw2r8fxHlOlrH3yUc9sKaNcQU883Lve9zhqdmqV08/tBwQEQKPT+sqXBUui19te2D8AmU/vqMWcvKtej3FNkuGqOpdKjWEc2wGRByFIfrcbHdRcc1LeJZMsSRq13fE9wa1L20ldQqpcP+U3tF5h6AFjf1/vuFtKSBEji7IEZ8QPxDaFD02h656+YMK2hwarHEQmqpSkTm/WEii3JQB8XdcJsxFhHRcAc3hHP0ldV5G1I1XnmGEblGXN4NvzeamZYadRRq7zRy1rUHXsZM/HccVrtox56JhrMmU6jAgGN2dF1R8wZMWrFade2WCVXaA/3EAFBVKK5oS42TE4kzkq/uQAQK76Ld549cxCeFA5Kd+89VGI7qXgKHVO/rBdwAXB257MfeHleLBl08/wAxBYeBqzz58yuhqkVTWtZJeEG7au6OiU0zBAHJ2feGRmwmFN5q+oTxG2+28nzHhyR6r3HpHZeXqUAxhoVb5OeoSomxdFcB+kABMXc7a0+I+cmTxzxFAAKwbmio3/wGc3XcBrNy5Vx14gBRMG9EtU5f87NqjalZuWL8f3xBsF5xMMUrJ4mY/LRYtIlOOGPpD2slDgxeIbPasKuWnky43Cn1pFWQ8mPpLRBlilNZqnO48g9G75uvakVmtxuk49/7i2pm8bObfcxUcp1Q2e9RgC8IoHCelIYhDVbxd75B7gojKh9z1iUhLwL5GbMPLBf38x4Rg7qefdcxJKqy/RfEdkKsTm9158xxTcILPCkhx8wtmTuql/UC9rUKGc5EF1oi2ywdAuvPx7jIFTRQSBac0rg3wS5EuV0X95zSpaQm6HAtfODnvcFsef3hkCF7yOomZRqBV29viWmOU2eq8RpbDb8zUxIRS8yqggK74isWMC2pgv8AjFfWIrf86IZGeDu9eZUc60nPmVmUctmeJMnT0w0oZfD/ALjqm08lGWORBWwHflhlCuMA8j5OoVRuHpPe5WcCLdi/HiFeiF/ifRKjrQItmz0ajTTI2Srzephyi21OTw34h2zyVojkfk8Mf57stn30W1xrUTtGRt26rxx9IMjGhsHSWfFeSLptmO2Sr1emHqPwW16fEdqhtswli6xFgRG6LYGn13LRQjYRWqcU++oZVqypb47xBgWSlbKwmMbv4hFULnlYrP8AdwLNuAyBVHWs1CZipGuP0/ExDVDRtjP2/EVVAYF5huymNwBQwEWr46lMcOzODM0LXjyR1taRvKtECwMAMa7XxAXVbKS6pegcTEbybuP/AA7iKiBlt7/4Rc+I1F/9E/yOSAXSu/DmMdLcpzDFsNjWmIHCTPR+gzaoNtbzuKoKEp2TMAqYFD9fMsG7pZH+/iAGiKAxnUAwNGhgH7k5P1JQprvXcBuCArdmlrAq+t6iWMHRlzBpAni8U3k8QFd2JR338MREs7gbPRu8wQCODTDuixd+Il9xUc29PDWzcAadaC+6tMFIpdjg4HjDm5RVBpi6auxx/MHZ6RsdhcfvLplULQVneKh+QTVAp9Z+OyMly4YGtglF3Rp5g7RCI9LCc8n0mdTWlFj11u8xRbFllB8iNfvGRgb3uJgvQqk0sdAbe0YUQF+cI1rcNywRdk49MvXVpxqqqHgZtSjHR+ZRQH6RFjAxijZcQowFf8cZ1OIx1/02uoRQ6YWQwrzdnuVZOwNkMYBDgYyo003fhYEr/hM2ALFNxD15p31CtujTVI43MuGOxngeHfUsKwoLP8MJTBRk1UbB7AGxpQeTmbtq+Y4pv3+e5kCvFUaflZeP3RMX0Rut76iALgVbf2Y5xEFdC3NFX3X+oE7BTf8ANAzB/g5awhtOLzzxCy6AB09098l7xiUA9s4B6w8cfeFYS0rDPf2uXrpMnIeMSsKRRhk8fRjSXLzu5zDyhy4+o+JfpOAQOEgs46sRcoYaQfiZCYUcfaYDAKrfzOeAvgijamw8wAFtiuDzLZZZAhuIA0/jxEpoiOUADnmbjRGonaJW5UUaiVb/ANK4gI5IWuDCLgdR87jTftLiIS2cxK1DSOv9wiDpVHII5/MsPBq2cfT1EmYIo2vHpg19kBpHniNTuAhy1z9/HzKGMDRXlON5mRb4rh+koJi2NpXkR/iZU0Bgq9iqNsr3DjBI2Z3rEoiUYB2ap/aOGzntC/zzC0lcLfnjf2g601bnDGBc/b9YOhAJuQ5aKMXAo/gbo1d1+32g0IZkFnWcP5uD447UF38+CA5uNWv9IxXQ4XJ61cVR3xgYfS5l8ELN/tK5wDlW+0eaZIEhKUYZRZ+bmlAY5wyOmkumKgybXcAyoHuHlUPLELILrqUgmrzBdRWWiUXGoINqDzAFlAJudHUdf9UGlJFylpF3MGV8l6evD+YBR2jZuvP1gvmmBpT8RGm5pa7U/WLBAUFp39Z4u8EFbv8ASIwCCVj0OmvxNSj62HjUNLB5loYJdGwfTevvEoHQJHXuPHdi0Oc438xGlfH4Vz1G9CrLaN7iYgZyFenuo4wAaVlPn67uEgw4APeKCaASscsZDqosiyiz9BrfUJRYYpv8Yhsbtrf6QpDvJnf0hucFMBXxcsRb4wYgygC6AGa4TpNx4sWeUuBaAVhqLyHKVEjYqFEqnxiOszHU1DYNMVgsdTIVRMAIO+tspUcG4j8f9cGlJMJPhvXtCRDtOKv9I+yCLaJSHsLCY6dRwq0V0DE4q2SU9dS7KyqfS68kxA7OIfctxtkwp0TsqDidMIxsVWzkv6Qtnzygg9wBjRYteKgiihcFvlb3LVa8bXEXURgy3EcCVxnEqBZYWYFgWelEVYD4EDJD06VMj9WG+pSZCucFe4xEPIb/ABK6oF9Sss7RsiKGHg2d6hU4zWbzmWAHrZRBFR6XLhADuIazleOfmKriP1TJcwdzGg48RH4/7JpVMfmGLmoLLRyRIqGKp0eyXToUyA+uP0iDSUgpB5IrugYLN2HH0IRpbIDe4yEg1mL2eGcQwEH0ZZnjOgeMxx4bbY7IWkbIOto1UoWFNKzqAix8mI24AZaPvBAXTaevcQXS27RbbTC0xyfQGr9TTRk03fm4slcK3LiMsdFIPfmAbMCgBlhAULq3P0nYBbHP3IUhSccvtLkk6cygb8lXnqZFAJVYk5ofpuNaxUNg34gROUeyExhxHX/bLMkBLcXwl2BPUx1E2jnshrkrVhy5p3z9YgWD+AJDoRCmeGNfeDNWGRY/3EYOdtuvbuL0Y4Sh/mXd3IZ/mZqF3w+0zNtZOQ5gKPEMsxdo6SienUdAnOg8Kh1Vs88fvFBiW8vTPzKZkMGabl82BVgh9xAoRCuLMQAFlNXbzAlhRzhvtxkiVXyy7V5YAAfPM2JM2GDxTEAAFYoEatjqgKSUNqHILuOitdHEAOJQ2o7XH0MRWv8A3r+0ePzLT8TCNacg+u5Qxdn2M3VMB6oLB8MUQRWulPDpjYtVm13+vzHUB7obfXmUx21lnxBqCKuoEMWNVkB/E8CcZPrFsJkKidRIN+gedjyTQm709TBbYZX7tesy0c5mArcbgJGUORDw+PiDuUHQ0+IsyBEOLOYHbDiAM8OYgDRuObHmbl1gs1AAxreYkXAWaIC/dRTuvXEXlSZDK+WDbPzG0/8ABFVjTFASkWs0LZPT+8K2fOAfh5hSWCfscS6LQKGfet+SEBw3d/v0ioog6ihBt1fJ5qC7pAMp4fECSzRWP7/WIqEZNKQBVYxsX3DJc21i4usQmSqPrE4ABVOv4l2OLdFxosweIiGM2PNxVJbVBivMdibs4PUAxCmMYgNTkdxVUHU1+ymU6/MCLw9wGsyzTFbf+IraRlAKyOJngyV8y+9NW4+v+pcLQ8j6YiRtDVOIyG2PWYkVw/nzSeYCvvsT8QywQkOayca+SYAAN5UheP8AUNG7Och9wKvEDD5g5NdZgDR4tPxDeGzd88eZaErv4g0Sucy0CV5xFSMF4DmC+2/AxxjHQjygYBj6sVbuK2f/ACBKxqalJCSr5R4Ffxp+pMWg5UaH99QHJoFlkcB9lM/aBU0zlMh8QQGxgyfTjnqOdKuQVflqDuKhwuCZJXsUlaAe13KZT2UyCAcGLhqgrVxwy3sltVmAttPuO8/SI1FXf/miNM1am6zPvihMpa7C4WMq9kL7yeGpjaxfTDqb+sS0E4Qm7+ib1vn/AIRbmKu//Wt7lvct3Le5f/4iv/aOhyGiXJQ4QvXny/SVwDVK4LapvxzW4NJORph4z+Y6l58C1x8/aC+HTIsKHvzXsjhbZBPkZ/mAN77Mw4d9ZgysGrTyhvxXOWD0AKsy45UOftGuIVesXzvX3xqKDGoV7HO6T6xWYJQowlDe/wBEtFEVoUq/ofeHF2CjWBBvfn7R5VAy4bo+gfWFolYoDlzdvX3hRc0woeMb3l+kSL8Rroxh9/SaaZ1WC3LGfj3K8FWJdqO+g73Gu/NAgDXO1E+kK+A0N0fq8H1l58i1rNGKzz5qLQqRaHF3z4+5Grxr/wAhV3FXf/ApKCxoxb/8W1LeTcRIV7f+LWP/ANKvP/CaIj4i25/4/9k=" name="Imagen 12" align="bottom" width="208" height="183" border="0"/></p>';
         Html::addHtml($section, $html);
@@ -551,7 +551,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
           'IMG_SRC_REPLACE' => $localPath,
         );
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p><img src="' . $src . '" width="150" height="200" style="float: right;"/></p>';
         Html::addHtml($section, $html, false, true, $options);
@@ -571,7 +571,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     {
         $src = 'https://fakedomain.io/images/firefox.png';
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p><img src="' . $src . '" width="150" height="200" style="float: right;"/></p>';
         Html::addHtml($section, $html, false, true);
@@ -579,7 +579,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
 
     public function testParseLink()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p><a href="http://phpword.readthedocs.io/" style="text-decoration: underline">link text</a></p>';
         Html::addHtml($section, $html);
@@ -591,7 +591,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink/w:r/w:rPr/w:u'));
         $this->assertEquals('single', $doc->getElementAttribute('/w:document/w:body/w:p/w:hyperlink/w:r/w:rPr/w:u', 'w:val'));
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addBookmark('bookmark');
         $html = '<p><a href="#bookmark">internal link text</a></p>';
@@ -605,7 +605,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
 
     public function testParseMalformedStyleIsIgnored()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p style="">text</p>';
         Html::addHtml($section, $html);
@@ -618,7 +618,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseHiddenText()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p style="display: hidden">This is some hidden text.</p>';
         Html::addHtml($section, $html);
@@ -633,7 +633,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseLetterSpacing()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p style="letter-spacing: 150px">This is some text with letter spacing.</p>';
         Html::addHtml($section, $html);
@@ -649,7 +649,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testInputCheckbox()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<input type="checkbox" checked="true" /><input type="checkbox" />';
         Html::addHtml($section, $html);
@@ -668,9 +668,9 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
      */
     public function testParseTableAndCellWidth()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection(array(
-            'orientation' => \PhpOffice\PhpWord\Style\Section::ORIENTATION_LANDSCAPE,
+            'orientation' => \Shareforce\PhpWord\Style\Section::ORIENTATION_LANDSCAPE,
         ));
 
         // borders & backgrounds are here just for better visual comparison
@@ -737,9 +737,9 @@ HTML;
      */
     public function testParseCellspacingRowBgColor()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection(array(
-            'orientation' => \PhpOffice\PhpWord\Style\Section::ORIENTATION_LANDSCAPE,
+            'orientation' => \Shareforce\PhpWord\Style\Section::ORIENTATION_LANDSCAPE,
         ));
 
         // borders & backgrounds are here just for better visual comparison
@@ -778,7 +778,7 @@ HTML;
      */
     public function testParseHorizRule()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
 
         // borders & backgrounds are here just for better visual comparison
@@ -819,7 +819,7 @@ HTML;
      */
     public function testParseOrderedList()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
 
         // borders & backgrounds are here just for better visual comparison
@@ -880,7 +880,7 @@ HTML;
      */
     public function testParseVerticalAlign()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
 
         // borders & backgrounds are here just for better visual comparison
@@ -920,7 +920,7 @@ HTML;
      */
     public function testDontDecodeAlreadyEncodedDoubleQuotes()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
 
         // borders & backgrounds are here just for better visual comparison

--- a/tests/PhpWord/Shared/Microsoft/PasswordEncoderTest.php
+++ b/tests/PhpWord/Shared/Microsoft/PasswordEncoderTest.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared\Microsoft;
+namespace Shareforce\PhpWord\Shared\Microsoft;
 
 /**
- * Test class for \PhpOffice\PhpWord\Shared\Microsoft
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\Microsoft
+ * Test class for \Shareforce\PhpWord\Shared\Microsoft
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\Microsoft
  */
 class PasswordEncoderTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Shared/TextTest.php
+++ b/tests/PhpWord/Shared/TextTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * Test class for Text
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\Text
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\Text
  */
 class TextTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Shared/XMLReaderTest.php
+++ b/tests/PhpWord/Shared/XMLReaderTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * Test class for XMLReader
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\XMLReader
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\XMLReader
  */
 class XMLReaderTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Shared/XMLWriterTest.php
+++ b/tests/PhpWord/Shared/XMLWriterTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
 /**
  * Test class for XMLWriter
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\XMLWriter
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\XMLWriter
  */
 class XMLWriterTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Shared/ZipArchiveTest.php
+++ b/tests/PhpWord/Shared/ZipArchiveTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Shared;
+namespace Shareforce\PhpWord\Shared;
 
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\Settings;
 
 /**
- * Test class for PhpOffice\PhpWord\Shared\ZipArchive
+ * Test class for Shareforce\PhpWord\Shared\ZipArchive
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Shared\ZipArchive
+ * @coversDefaultClass \Shareforce\PhpWord\Shared\ZipArchive
  * @runTestsInSeparateProcesses
  */
 class ZipArchiveTest extends \PHPUnit\Framework\TestCase
@@ -30,7 +30,7 @@ class ZipArchiveTest extends \PHPUnit\Framework\TestCase
 //     /**
 //      * Test close method exception: Working in local, not working in Travis
 //      *
-//      * expectedException \PhpOffice\PhpWord\Exception\Exception
+//      * expectedException \Shareforce\PhpWord\Exception\Exception
 //      * expectedExceptionMessage Could not close zip file
 //      * covers ::close
 //      */
@@ -109,7 +109,7 @@ class ZipArchiveTest extends \PHPUnit\Framework\TestCase
      */
     public function testPCLZip()
     {
-        $this->testZipArchive('PhpOffice\PhpWord\Shared\ZipArchive');
+        $this->testZipArchive('Shareforce\PhpWord\Shared\ZipArchive');
     }
 
     /**

--- a/tests/PhpWord/Style/AbstractStyleTest.php
+++ b/tests/PhpWord/Style/AbstractStyleTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\AbstractStyle
+ * Test class for Shareforce\PhpWord\Style\AbstractStyle
  *
  * @runTestsInSeparateProcesses
  */
@@ -29,7 +29,7 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetStyleByArray()
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        $stub = $this->getMockForAbstractClass('\Shareforce\PhpWord\Style\AbstractStyle');
         $stub->setStyleByArray(array('index' => 1));
 
         $this->assertEquals(1, $stub->getIndex());
@@ -40,7 +40,7 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetValNormal()
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        $stub = $this->getMockForAbstractClass('\Shareforce\PhpWord\Style\AbstractStyle');
 
         $this->assertTrue(self::callProtectedMethod($stub, 'setBoolVal', array(true, false)));
         $this->assertEquals(12, self::callProtectedMethod($stub, 'setIntVal', array(12, 200)));
@@ -54,7 +54,7 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetValDefault()
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        $stub = $this->getMockForAbstractClass('\Shareforce\PhpWord\Style\AbstractStyle');
 
         $this->assertNotTrue(self::callProtectedMethod($stub, 'setBoolVal', array('a', false)));
         $this->assertEquals(200, self::callProtectedMethod($stub, 'setIntVal', array('foo', 200)));
@@ -69,7 +69,7 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetValEnumException()
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        $stub = $this->getMockForAbstractClass('\Shareforce\PhpWord\Style\AbstractStyle');
 
         $this->assertEquals('b', self::callProtectedMethod($stub, 'setEnumVal', array('z', array('a', 'b'), 'b')));
     }

--- a/tests/PhpWord/Style/CellTest.php
+++ b/tests/PhpWord/Style/CellTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\VerticalJc;
+use Shareforce\PhpWord\SimpleType\VerticalJc;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Cell
+ * Test class for Shareforce\PhpWord\Style\Cell
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Cell
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Cell
  * @runTestsInSeparateProcesses
  */
 class CellTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/Style/ChartTest.php
+++ b/tests/PhpWord/Style/ChartTest.php
@@ -15,12 +15,12 @@
  * @license   http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Chart
+ * Test class for Shareforce\PhpWord\Style\Chart
  *
- * @coversDefaultClass          \PhpOffice\PhpWord\Style\Chart
+ * @coversDefaultClass          \Shareforce\PhpWord\Style\Chart
  * @runTestsInSeparateProcesses
  */
 class ChartTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/Style/FontTest.php
+++ b/tests/PhpWord/Style/FontTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Font
+ * Test class for Shareforce\PhpWord\Style\Font
  *
  * @runTestsInSeparateProcesses
  */
@@ -44,7 +44,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
         $object = new Font('text', array('alignment' => Jc::BOTH));
 
         $this->assertEquals('text', $object->getStyleType());
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $object->getParagraphStyle());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', $object->getParagraphStyle());
         $this->assertInternalType('array', $object->getStyleValues());
     }
 
@@ -172,7 +172,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
     /**
      * Test line height exception by using nonnumeric value
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidStyleException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidStyleException
      */
     public function testLineHeightException()
     {
@@ -187,7 +187,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
     {
         $object = new Font();
         $object->setLang(Language::FR_BE);
-        $this->assertInstanceOf('PhpOffice\PhpWord\Style\Language', $object->getLang());
+        $this->assertInstanceOf('Shareforce\PhpWord\Style\Language', $object->getLang());
         $this->assertEquals(Language::FR_BE, $object->getLang()->getLatin());
     }
 }

--- a/tests/PhpWord/Style/ImageTest.php
+++ b/tests/PhpWord/Style/ImageTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Image
+ * Test class for Shareforce\PhpWord\Style\Image
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Image
  * @runTestsInSeparateProcesses
  */
 class ImageTest extends \PHPUnit\Framework\TestCase
@@ -68,11 +68,11 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             'marginTop'          => 240,
             'marginLeft'         => 240,
             'position'           => 10,
-            'positioning'        => \PhpOffice\PhpWord\Style\Image::POSITION_ABSOLUTE,
-            'posHorizontal'      => \PhpOffice\PhpWord\Style\Image::POSITION_HORIZONTAL_CENTER,
-            'posVertical'        => \PhpOffice\PhpWord\Style\Image::POSITION_VERTICAL_TOP,
-            'posHorizontalRel'   => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_COLUMN,
-            'posVerticalRel'     => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_IMARGIN,
+            'positioning'        => \Shareforce\PhpWord\Style\Image::POSITION_ABSOLUTE,
+            'posHorizontal'      => \Shareforce\PhpWord\Style\Image::POSITION_HORIZONTAL_CENTER,
+            'posVertical'        => \Shareforce\PhpWord\Style\Image::POSITION_VERTICAL_TOP,
+            'posHorizontalRel'   => \Shareforce\PhpWord\Style\Image::POSITION_RELATIVE_TO_COLUMN,
+            'posVerticalRel'     => \Shareforce\PhpWord\Style\Image::POSITION_RELATIVE_TO_IMARGIN,
             'wrapDistanceLeft'   => 10,
             'wrapDistanceRight'  => 20,
             'wrapDistanceTop'    => 30,

--- a/tests/PhpWord/Style/IndentationTest.php
+++ b/tests/PhpWord/Style/IndentationTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Indentation
+ * Test class for Shareforce\PhpWord\Style\Indentation
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Indentation
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Indentation
  */
 class IndentationTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/LanguageTest.php
+++ b/tests/PhpWord/Style/LanguageTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 use PHPUnit\Framework\Assert;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Language
+ * Test class for Shareforce\PhpWord\Style\Language
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Language
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Language
  */
 class LanguageTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/LineNumberingTest.php
+++ b/tests/PhpWord/Style/LineNumberingTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\LineNumbering
+ * Test class for Shareforce\PhpWord\Style\LineNumbering
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\LineNumbering
+ * @coversDefaultClass \Shareforce\PhpWord\Style\LineNumbering
  */
 class LineNumberingTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/LineTest.php
+++ b/tests/PhpWord/Style/LineTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Image
+ * Test class for Shareforce\PhpWord\Style\Image
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Image
  * @runTestsInSeparateProcesses
  */
 class LineTest extends \PHPUnit\Framework\TestCase
@@ -33,10 +33,10 @@ class LineTest extends \PHPUnit\Framework\TestCase
         $object = new Line();
 
         $properties = array(
-            'connectorType' => \PhpOffice\PhpWord\Style\Line::CONNECTOR_TYPE_STRAIGHT,
-            'beginArrow'    => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
-            'endArrow'      => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_OVAL,
-            'dash'          => \PhpOffice\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
+            'connectorType' => \Shareforce\PhpWord\Style\Line::CONNECTOR_TYPE_STRAIGHT,
+            'beginArrow'    => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
+            'endArrow'      => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_OVAL,
+            'dash'          => \Shareforce\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
             'weight'        => 10,
             'color'         => 'red',
         );
@@ -56,10 +56,10 @@ class LineTest extends \PHPUnit\Framework\TestCase
         $object = new Line();
 
         $properties = array(
-            'connectorType' => \PhpOffice\PhpWord\Style\Line::CONNECTOR_TYPE_STRAIGHT,
-            'beginArrow'    => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
-            'endArrow'      => \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_OVAL,
-            'dash'          => \PhpOffice\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
+            'connectorType' => \Shareforce\PhpWord\Style\Line::CONNECTOR_TYPE_STRAIGHT,
+            'beginArrow'    => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_BLOCK,
+            'endArrow'      => \Shareforce\PhpWord\Style\Line::ARROW_STYLE_OVAL,
+            'dash'          => \Shareforce\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT,
             'weight'        => 10,
             'color'         => 'red',
         );
@@ -86,7 +86,7 @@ class LineTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetConnectorType()
     {
-        $expected = \PhpOffice\PhpWord\Style\Line::CONNECTOR_TYPE_STRAIGHT;
+        $expected = \Shareforce\PhpWord\Style\Line::CONNECTOR_TYPE_STRAIGHT;
         $object = new Line();
         $object->setConnectorType($expected);
         $this->assertEquals($expected, $object->getConnectorType());
@@ -119,7 +119,7 @@ class LineTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetDash()
     {
-        $expected = \PhpOffice\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT;
+        $expected = \Shareforce\PhpWord\Style\Line::DASH_STYLE_LONG_DASH_DOT_DOT;
         $object = new Line();
         $object->setDash($expected);
         $this->assertEquals($expected, $object->getDash());
@@ -130,7 +130,7 @@ class LineTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetBeginArrow()
     {
-        $expected = \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_BLOCK;
+        $expected = \Shareforce\PhpWord\Style\Line::ARROW_STYLE_BLOCK;
         $object = new Line();
         $object->setBeginArrow($expected);
         $this->assertEquals($expected, $object->getBeginArrow());
@@ -141,7 +141,7 @@ class LineTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetEndArrow()
     {
-        $expected = \PhpOffice\PhpWord\Style\Line::ARROW_STYLE_CLASSIC;
+        $expected = \Shareforce\PhpWord\Style\Line::ARROW_STYLE_CLASSIC;
         $object = new Line();
         $object->setEndArrow($expected);
         $this->assertEquals($expected, $object->getEndArrow());

--- a/tests/PhpWord/Style/ListItemTest.php
+++ b/tests/PhpWord/Style/ListItemTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\ListItem
+ * Test class for Shareforce\PhpWord\Style\ListItem
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\ListItem
+ * @coversDefaultClass \Shareforce\PhpWord\Style\ListItem
  * @runTestsInSeparateProcesses
  */
 class ListItemTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/Style/NumberingLevelTest.php
+++ b/tests/PhpWord/Style/NumberingLevelTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\NumberingLevel
+ * Test class for Shareforce\PhpWord\Style\NumberingLevel
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Style/NumberingTest.php
+++ b/tests/PhpWord/Style/NumberingTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Numbering
+ * Test class for Shareforce\PhpWord\Style\Numbering
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Numbering
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Numbering
  */
 class NumberingTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/PaperTest.php
+++ b/tests/PhpWord/Style/PaperTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Paper
+ * Test class for Shareforce\PhpWord\Style\Paper
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Style/ParagraphTest.php
+++ b/tests/PhpWord/Style/ParagraphTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\LineSpacingRule;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\LineSpacingRule;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Paragraph
+ * Test class for Shareforce\PhpWord\Style\Paragraph
  *
  * @runTestsInSeparateProcesses
  */
@@ -178,7 +178,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
     /**
      * Test line height exception by using nonnumeric value
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\InvalidStyleException
+     * @expectedException \Shareforce\PhpWord\Exception\InvalidStyleException
      */
     public function testLineHeightException()
     {

--- a/tests/PhpWord/Style/RowTest.php
+++ b/tests/PhpWord/Style/RowTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Row
+ * Test class for Shareforce\PhpWord\Style\Row
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Row
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Row
  * @runTestsInSeparateProcesses
  */
 class RowTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/Style/SectionTest.php
+++ b/tests/PhpWord/Style/SectionTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\VerticalJc;
+use Shareforce\PhpWord\SimpleType\VerticalJc;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Section
+ * Test class for Shareforce\PhpWord\Style\Section
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Element\Section
+ * @coversDefaultClass \Shareforce\PhpWord\Element\Section
  * @runTestsInSeparateProcesses
  */
 class SectionTest extends \PHPUnit\Framework\TestCase
@@ -73,7 +73,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
                 'restart'   => 'newPage',
             )
         );
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\LineNumbering', $oSettings->getLineNumbering());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\LineNumbering', $oSettings->getLineNumbering());
 
         $oSettings->setSettingValue('lineNumbering', null);
         $this->assertNull($oSettings->getLineNumbering());
@@ -307,10 +307,10 @@ class SectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(720, $oSettings->getColsSpace());
 
         $iVal = rand(1, 1000);
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Section', $oSettings->setColsSpace($iVal));
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Section', $oSettings->setColsSpace($iVal));
         $this->assertEquals($iVal, $oSettings->getColsSpace());
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Section', $oSettings->setColsSpace());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Section', $oSettings->setColsSpace());
         $this->assertEquals(720, $oSettings->getColsSpace());
     }
 

--- a/tests/PhpWord/Style/ShadingTest.php
+++ b/tests/PhpWord/Style/ShadingTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Shading
+ * Test class for Shareforce\PhpWord\Style\Shading
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Shading
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Shading
  */
 class ShadingTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/SpacingTest.php
+++ b/tests/PhpWord/Style/SpacingTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Spacing
+ * Test class for Shareforce\PhpWord\Style\Spacing
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Spacing
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Spacing
  */
 class SpacingTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/TOCTest.php
+++ b/tests/PhpWord/Style/TOCTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\TOC
+ * Test class for Shareforce\PhpWord\Style\TOC
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\TOC
+ * @coversDefaultClass \Shareforce\PhpWord\Style\TOC
  */
 class TOCTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/TabTest.php
+++ b/tests/PhpWord/Style/TabTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Tab
+ * Test class for Shareforce\PhpWord\Style\Tab
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Tab
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Tab
  */
 class TabTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Style/TablePositionTest.php
+++ b/tests/PhpWord/Style/TablePositionTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Table
+ * Test class for Shareforce\PhpWord\Style\Table
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Style/TableTest.php
+++ b/tests/PhpWord/Style/TableTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
-use PhpOffice\PhpWord\SimpleType\JcTable;
-use PhpOffice\PhpWord\SimpleType\TblWidth;
+use Shareforce\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
+use Shareforce\PhpWord\SimpleType\JcTable;
+use Shareforce\PhpWord\SimpleType\TblWidth;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Table
+ * Test class for Shareforce\PhpWord\Style\Table
  *
  * @runTestsInSeparateProcesses
  */
@@ -44,7 +44,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('FF0000', $object->getBgColor());
 
         $firstRow = $object->getFirstRow();
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Table', $firstRow);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Table', $firstRow);
         $this->assertEquals(3, $firstRow->getBorderBottomSize());
     }
 

--- a/tests/PhpWord/Style/TextBoxTest.php
+++ b/tests/PhpWord/Style/TextBoxTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Style;
+namespace Shareforce\PhpWord\Style;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Style\Image
+ * Test class for Shareforce\PhpWord\Style\Image
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
+ * @coversDefaultClass \Shareforce\PhpWord\Style\Image
  * @runTestsInSeparateProcesses
  */
 class TextBoxTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/StyleTest.php
+++ b/tests/PhpWord/StyleTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Style
+ * Test class for Shareforce\PhpWord\Style
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Style
+ * @coversDefaultClass \Shareforce\PhpWord\Style
  * @runTestsInSeparateProcesses
  */
 class StyleTest extends \PHPUnit\Framework\TestCase
@@ -82,7 +82,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(count($styles), Style::getStyles());
         foreach ($styles as $name => $style) {
-            $this->assertInstanceOf("PhpOffice\\PhpWord\\Style\\{$style}", Style::getStyle($name));
+            $this->assertInstanceOf("Shareforce\\PhpWord\\Style\\{$style}", Style::getStyle($name));
         }
         $this->assertNull(Style::getStyle('Unknown'));
 
@@ -102,6 +102,6 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
         Style::setDefaultParagraphStyle($paragraph);
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', Style::getStyle('Normal'));
+        $this->assertInstanceOf('Shareforce\\PhpWord\\Style\\Paragraph', Style::getStyle('Normal'));
     }
 }

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Element\Text;
-use PhpOffice\PhpWord\Element\TextRun;
+use Shareforce\PhpWord\Element\Text;
+use Shareforce\PhpWord\Element\TextRun;
 
 /**
- * @covers \PhpOffice\PhpWord\TemplateProcessor
- * @coversDefaultClass \PhpOffice\PhpWord\TemplateProcessor
+ * @covers \Shareforce\PhpWord\TemplateProcessor
+ * @coversDefaultClass \Shareforce\PhpWord\TemplateProcessor
  * @runTestsInSeparateProcesses
  */
 final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
@@ -36,7 +36,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
     public function testTheConstruct()
     {
         $object = new TemplateProcessor(__DIR__ . '/_files/templates/blank.docx');
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\TemplateProcessor', $object);
+        $this->assertInstanceOf('Shareforce\\PhpWord\\TemplateProcessor', $object);
         $this->assertEquals(array(), $object->getVariables());
     }
 
@@ -134,7 +134,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
      * XSL stylesheet cannot be applied on failure in setting parameter value.
      *
      * @covers                   ::applyXslStyleSheet
-     * @expectedException        \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException        \Shareforce\PhpWord\Exception\Exception
      * @expectedExceptionMessage Could not set values for the given XSL style sheet parameters.
      * @test
      */
@@ -161,7 +161,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
      * XSL stylesheet can be applied on failure of loading XML from template.
      *
      * @covers                   ::applyXslStyleSheet
-     * @expectedException        \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException        \Shareforce\PhpWord\Exception\Exception
      * @expectedExceptionMessage Could not load the given XML document.
      * @test
      */
@@ -439,15 +439,15 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
 
         // dynamic generated doc
         $testFileName = 'images-test-sample.docx';
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('${Test:width=100:ratio=true}');
-        $objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'Word2007');
+        $objWriter = \Shareforce\PhpWord\IOFactory::createWriter($phpWord, 'Word2007');
         $objWriter->save($testFileName);
         $this->assertFileExists($testFileName, "Generated file '{$testFileName}' not found!");
 
         $resultFileName = 'images-test-result.docx';
-        $templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor($testFileName);
+        $templateProcessor = new \Shareforce\PhpWord\TemplateProcessor($testFileName);
         unlink($testFileName);
         $templateProcessor->setImageValue('Test', $imagePath);
         $templateProcessor->setImageValue('Test1', $imagePath);
@@ -566,7 +566,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         // and the placeholders have been replaced correctly
         $phpWord = IOFactory::load($templatePath);
         $sections = $phpWord->getSections();
-        /** @var \PhpOffice\PhpWord\Element\TextRun[] $actualElements */
+        /** @var \Shareforce\PhpWord\Element\TextRun[] $actualElements */
         $actualElements = $sections[0]->getElements();
         unlink($templatePath);
         $expectedElements = array(

--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -15,17 +15,17 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML;
+namespace Shareforce\PhpWord\Writer\HTML;
 
-use PhpOffice\PhpWord\Element\Text as TextElement;
-use PhpOffice\PhpWord\Element\TextRun;
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Writer\HTML;
-use PhpOffice\PhpWord\Writer\HTML\Element\Text;
+use Shareforce\PhpWord\Element\Text as TextElement;
+use Shareforce\PhpWord\Element\TextRun;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Writer\HTML;
+use Shareforce\PhpWord\Writer\HTML\Element\Text;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\HTML\Element subnamespace
+ * Test class for Shareforce\PhpWord\Writer\HTML\Element subnamespace
  */
 class ElementTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,9 +36,9 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     {
         $elements = array('Container', 'Footnote', 'Image', 'Link', 'ListItem', 'ListItemRun', 'Table', 'Title', 'Bookmark');
         foreach ($elements as $element) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\HTML\\Element\\' . $element;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\HTML\\Element\\' . $element;
             $parentWriter = new HTML();
-            $newElement = new \PhpOffice\PhpWord\Element\PageBreak();
+            $newElement = new \Shareforce\PhpWord\Element\PageBreak();
             $object = new $objectClass($parentWriter, $newElement);
 
             $this->assertEquals('', $object->write());
@@ -197,11 +197,11 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $section = $phpWord->addSection();
         $section->addTable();
 
-        $table1 = $section->addTable(array('layout' => \PhpOffice\PhpWord\Style\Table::LAYOUT_FIXED));
+        $table1 = $section->addTable(array('layout' => \Shareforce\PhpWord\Style\Table::LAYOUT_FIXED));
         $row1 = $table1->addRow();
         $row1->addCell()->addText('fixed layout table');
 
-        $table2 = $section->addTable(array('layout' => \PhpOffice\PhpWord\Style\Table::LAYOUT_AUTO));
+        $table2 = $section->addTable(array('layout' => \Shareforce\PhpWord\Style\Table::LAYOUT_AUTO));
         $row2 = $table2->addRow();
         $row2->addCell()->addText('auto layout table');
 

--- a/tests/PhpWord/Writer/HTML/PartTest.php
+++ b/tests/PhpWord/Writer/HTML/PartTest.php
@@ -15,19 +15,19 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML;
+namespace Shareforce\PhpWord\Writer\HTML;
 
-use PhpOffice\PhpWord\Writer\HTML\Part\Body;
+use Shareforce\PhpWord\Writer\HTML\Part\Body;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\HTML\Part subnamespace
+ * Test class for Shareforce\PhpWord\Writer\HTML\Part subnamespace
  */
 class PartTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get parent writer exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      */
     public function testGetParentWriterException()
     {

--- a/tests/PhpWord/Writer/HTML/StyleTest.php
+++ b/tests/PhpWord/Writer/HTML/StyleTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\HTML;
+namespace Shareforce\PhpWord\Writer\HTML;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\HTML\Style subnamespace
+ * Test class for Shareforce\PhpWord\Writer\HTML\Style subnamespace
  */
 class StyleTest extends \PHPUnit\Framework\TestCase
 {
@@ -29,7 +29,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     {
         $styles = array('Font', 'Paragraph', 'Image');
         foreach ($styles as $style) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\HTML\\Style\\' . $style;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\HTML\\Style\\' . $style;
             $object = new $objectClass();
 
             $this->assertEquals('', $object->write());

--- a/tests/PhpWord/Writer/HTMLTest.php
+++ b/tests/PhpWord/Writer/HTMLTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\AbstractWebServerEmbeddedTest;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\AbstractWebServerEmbeddedTest;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\HTML
+ * Test class for Shareforce\PhpWord\Writer\HTML
  *
  * @runTestsInSeparateProcesses
  */
@@ -36,13 +36,13 @@ class HTMLTest extends AbstractWebServerEmbeddedTest
     {
         $object = new HTML(new PhpWord());
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $object->getPhpWord());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $object->getPhpWord());
     }
 
     /**
      * Construct with null
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      * @expectedExceptionMessage No PhpWord assigned.
      */
     public function testConstructWithNull()

--- a/tests/PhpWord/Writer/ODText/Element/ImageTest.php
+++ b/tests/PhpWord/Writer/ODText/Element/ImageTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
-use PhpOffice\PhpWord\Style\Image;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\Style\Image;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\ODText\Element\Image
+ * Test class for Shareforce\PhpWord\Writer\ODText\Element\Image
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\ODText\Element\Image
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\ODText\Element\Image
  */
 class ImageTest extends \PHPUnit\Framework\TestCase
 {
@@ -40,7 +40,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
      */
     public function testImage1()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addImage(__DIR__ . '/../../../_files/images/earth.jpg');
         $section->addImage(__DIR__ . '/../../../_files/images/mario.gif', array('align' => 'end'));

--- a/tests/PhpWord/Writer/ODText/ElementTest.php
+++ b/tests/PhpWord/Writer/ODText/ElementTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText;
+namespace Shareforce\PhpWord\Writer\ODText;
 
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\ODText\Element subnamespace
+ * Test class for Shareforce\PhpWord\Writer\ODText\Element subnamespace
  */
 class ElementTest extends \PHPUnit\Framework\TestCase
 {
@@ -42,9 +42,9 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     {
         $elements = array('Image', 'Link', 'Table', 'Text', 'Title', 'Field');
         foreach ($elements as $element) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\ODText\\Element\\' . $element;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\ODText\\Element\\' . $element;
             $xmlWriter = new XMLWriter();
-            $newElement = new \PhpOffice\PhpWord\Element\PageBreak();
+            $newElement = new \Shareforce\PhpWord\Element\PageBreak();
             $object = new $objectClass($xmlWriter, $newElement);
             $object->write();
 
@@ -98,7 +98,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
 
-        $table = $section->addTable(array('alignment' => \PhpOffice\PhpWord\SimpleType\JcTable::CENTER));
+        $table = $section->addTable(array('alignment' => \Shareforce\PhpWord\SimpleType\JcTable::CENTER));
         $table->addRow(900);
         $table->addCell(2000)->addText('Row 1');
         $table->addCell(2000)->addText('Row 2');
@@ -124,7 +124,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         self::AssertNotEquals('', $tableStyleName);
         $element = "$element/style:table-properties";
         self::assertTrue($doc->elementExists($element));
-        self::assertEquals(\PhpOffice\PhpWord\SimpleType\JcTable::CENTER, $doc->getElementAttribute($element, 'table:align'));
+        self::assertEquals(\Shareforce\PhpWord\SimpleType\JcTable::CENTER, $doc->getElementAttribute($element, 'table:align'));
         $p2t = '/office:document-content/office:body/office:text/text:section';
         $tableRootElement = "$p2t/table:table";
         self::assertTrue($doc->elementExists($tableRootElement));
@@ -193,12 +193,12 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testTextRunTitle()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $phpWord->addTitleStyle(1, array('name' => 'Times New Roman', 'size' => 18, 'bold' => true));
         $section = $phpWord->addSection();
         $section->addTitle('Text Title', 1);
         $section->addText('Text following Text Title');
-        $textRun = new \PhpOffice\PhpWord\Element\TextRun();
+        $textRun = new \Shareforce\PhpWord\Element\TextRun();
         $textRun->addText('Text Run');
         $textRun->addText(' Title');
         $section->addTitle($textRun, 1);
@@ -234,15 +234,15 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testTextWithAmpersand()
     {
-        $esc = \PhpOffice\PhpWord\Settings::isOutputEscapingEnabled();
-        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
+        $esc = \Shareforce\PhpWord\Settings::isOutputEscapingEnabled();
+        \Shareforce\PhpWord\Settings::setOutputEscapingEnabled(true);
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
         $txt = 'this text contains an & (ampersand)';
         $section->addText($txt);
 
         $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
-        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled($esc);
+        \Shareforce\PhpWord\Settings::setOutputEscapingEnabled($esc);
         $p2t = '/office:document-content/office:body/office:text/text:section';
         $element = "$p2t/text:p[2]";
         $this->assertTrue($doc->elementExists($element));
@@ -273,7 +273,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testTrackedChanges()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
 
         // New portrait section
         $section = $phpWord->addSection();

--- a/tests/PhpWord/Writer/ODText/Part/AbstractPartTest.php
+++ b/tests/PhpWord/Writer/ODText/Part/AbstractPartTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
-use PhpOffice\PhpWord\Writer\ODText;
+use Shareforce\PhpWord\Writer\ODText;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\ODText\Part\AbstractPart
+ * Test class for Shareforce\PhpWord\Writer\ODText\Part\AbstractPart
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\ODText\Part\AbstractPart
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\ODText\Part\AbstractPart
  */
 class AbstractPartTest extends \PHPUnit\Framework\TestCase
 {
@@ -32,7 +32,7 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetParentWriter()
     {
-        $object = $this->getMockForAbstractClass('PhpOffice\\PhpWord\\Writer\\ODText\\Part\\AbstractPart');
+        $object = $this->getMockForAbstractClass('Shareforce\\PhpWord\\Writer\\ODText\\Part\\AbstractPart');
         $object->setParentWriter(new ODText());
         $this->assertEquals(new ODText(), $object->getParentWriter());
     }
@@ -45,7 +45,7 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetParentWriterNull()
     {
-        $object = $this->getMockForAbstractClass('PhpOffice\\PhpWord\\Writer\\ODText\\Part\\AbstractPart');
+        $object = $this->getMockForAbstractClass('Shareforce\\PhpWord\\Writer\\ODText\\Part\\AbstractPart');
         $object->getParentWriter();
     }
 }

--- a/tests/PhpWord/Writer/ODText/Part/ContentTest.php
+++ b/tests/PhpWord/Writer/ODText/Part/ContentTest.php
@@ -15,16 +15,16 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Part;
+namespace Shareforce\PhpWord\Writer\ODText\Part;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\ODText\Part\Content
+ * Test class for Shareforce\PhpWord\Writer\ODText\Part\Content
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\ODText\Part\Content
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\ODText\Part\Content
  */
 class ContentTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Writer/ODText/Style/FontTest.php
+++ b/tests/PhpWord/Writer/ODText/Style/FontTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
  * Test class for Headers, Footers, Tabs in ODT
@@ -38,11 +38,11 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testColors()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('This is red (800) in rtf/html, default in docx/odt', array('color' => '800'));
         $section->addText('This should be cyanish (008787)', array('color' => '008787'));
-        $section->addText('This should be dark green (FGCOLOR_DARKGREEN)', array('color' => \PhpOffice\PhpWord\Style\Font::FGCOLOR_DARKGREEN));
+        $section->addText('This should be dark green (FGCOLOR_DARKGREEN)', array('color' => \Shareforce\PhpWord\Style\Font::FGCOLOR_DARKGREEN));
         $section->addText('This color is default (unknow)', array('color' => 'unknow'));
 
         $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
@@ -105,7 +105,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testAllNamedColors($namedColor, $rgbColor)
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('This is red (800) in rtf/html, default in docx/odt', array('color' => '800'));
         $section->addText('This should be cyanish (008787)', array('color' => '008787'));
@@ -134,7 +134,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testNoProof()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('Noproof not specified', array('color' => 'black'));
         $section->addText('Noproof is true', array('color' => 'black', 'noproof' => true));
@@ -190,7 +190,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testNamedStyleAsObject()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $named = $phpWord->addFontStyle('namedobject', array('color' => '008787'));
         $section = $phpWord->addSection();
         $section->addText('Let us see what color we wind up with', $named);
@@ -208,7 +208,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testFieldStyles()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $namedstyle = $phpWord->addFontStyle('namedstyle', array('color' => '800000'));
         $section = $phpWord->addSection();
         $textrun = $section->addTextRun();
@@ -219,7 +219,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
         $fld->setFontStyle(array('color' => '008000'));
         $textrun = $section->addTextRun();
         $fld = $textrun->addField('DATE');
-        $font = new \PhpOffice\PhpWord\Style\Font();
+        $font = new \Shareforce\PhpWord\Style\Font();
         $font->setColor('000080');
         $fld->setFontStyle($font);
         $textrun = $section->addTextRun();

--- a/tests/PhpWord/Writer/ODText/Style/ParagraphTest.php
+++ b/tests/PhpWord/Writer/ODText/Style/ParagraphTest.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\Converter;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\Converter;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
  * Test class for Headers, Footers, Tabs in ODT
@@ -363,7 +363,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
      */
     public function testTextRun()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $phpWord->addParagraphStyle('parstyle1', array('align' => 'start'));
         $phpWord->addParagraphStyle('parstyle2', array('align' => 'end'));
         $section = $phpWord->addSection();
@@ -403,7 +403,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
      */
     public function testTextRunUnnamed()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $parstyle1 = array('align' => 'start');
         $parstyle2 = array('align' => 'end');
         $section = $phpWord->addSection();
@@ -437,7 +437,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyFontAndParagraphStyles()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $phpWord->addFontStyle('namedfont', array('name' => 'Courier New', 'size' => 8));
         $phpWord->addParagraphStyle('namedpar', array('lineHeight' => 1.08));

--- a/tests/PhpWord/Writer/ODText/Style/SectionTest.php
+++ b/tests/PhpWord/Writer/ODText/Style/SectionTest.php
@@ -15,10 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText\Style;
+namespace Shareforce\PhpWord\Writer\ODText\Style;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
  * Test class for Headers, Footers, Tabs in ODT
@@ -38,8 +38,8 @@ class SectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testHeaderFooterTabs()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
-        $margins = \PhpOffice\PhpWord\Shared\Converter::INCH_TO_TWIP;
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
+        $margins = \Shareforce\PhpWord\Shared\Converter::INCH_TO_TWIP;
         $phpWord->addFontStyle('hdrstyle1', array('name' => 'Courier New', 'size' => 8));
         $section = $phpWord->addSection(array('paperSize' => 'Letter', 'marginTop' => $margins, 'marginBottom' => $margins));
         $header = $section->createHeader();
@@ -54,8 +54,8 @@ class SectionTest extends \PHPUnit\Framework\TestCase
             'footerTab',
             array(
                 'tabs' => array(
-                    new \PhpOffice\PhpWord\Style\Tab('center', (int) ($footerwidth / 2)),
-                    new \PhpOffice\PhpWord\Style\Tab('right', (int) $footerwidth),
+                    new \Shareforce\PhpWord\Style\Tab('center', (int) ($footerwidth / 2)),
+                    new \Shareforce\PhpWord\Style\Tab('right', (int) $footerwidth),
                 ),
             )
         );
@@ -151,8 +151,8 @@ class SectionTest extends \PHPUnit\Framework\TestCase
         $phpWord = new PhpWord();
         $phpWord->getSettings()->setHideGrammaticalErrors(true);
         $phpWord->getSettings()->setHideSpellingErrors(true);
-        $phpWord->getSettings()->setThemeFontLang(new \PhpOffice\PhpWord\Style\Language('en-US'));
-        $phpWord->getSettings()->getThemeFontLang()->setLangId(\PhpOffice\PhpWord\Style\Language::EN_US_ID);
+        $phpWord->getSettings()->setThemeFontLang(new \Shareforce\PhpWord\Style\Language('en-US'));
+        $phpWord->getSettings()->getThemeFontLang()->setLangId(\Shareforce\PhpWord\Style\Language::EN_US_ID);
         $section = $phpWord->addSection();
         $section->addText('Here is a paragraph with some speling errorz');
 

--- a/tests/PhpWord/Writer/ODText/StyleTest.php
+++ b/tests/PhpWord/Writer/ODText/StyleTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\ODText;
+namespace Shareforce\PhpWord\Writer\ODText;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\ODText\Style subnamespace
+ * Test class for Shareforce\PhpWord\Writer\ODText\Style subnamespace
  */
 class StyleTest extends \PHPUnit\Framework\TestCase
 {
@@ -31,7 +31,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     {
         $styles = array('Font', 'Paragraph', 'Image', 'Section', 'Table');
         foreach ($styles as $style) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\ODText\\Style\\' . $style;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\ODText\\Style\\' . $style;
             $xmlWriter = new XMLWriter();
             $object = new $objectClass($xmlWriter);
             $object->write();

--- a/tests/PhpWord/Writer/ODTextTest.php
+++ b/tests/PhpWord/Writer/ODTextTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\ODText
+ * Test class for Shareforce\PhpWord\Writer\ODText
  *
  * @runTestsInSeparateProcesses
  */
@@ -34,16 +34,16 @@ class ODTextTest extends \PHPUnit\Framework\TestCase
     {
         $object = new ODText(new PhpWord());
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $object->getPhpWord());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $object->getPhpWord());
 
         $this->assertEquals('./', $object->getDiskCachingDirectory());
         foreach (array('Content', 'Manifest', 'Meta', 'Mimetype', 'Styles') as $part) {
             $this->assertInstanceOf(
-                "PhpOffice\\PhpWord\\Writer\\ODText\\Part\\{$part}",
+                "Shareforce\\PhpWord\\Writer\\ODText\\Part\\{$part}",
                 $object->getWriterPart($part)
             );
             $this->assertInstanceOf(
-                'PhpOffice\\PhpWord\\Writer\\ODText',
+                'Shareforce\\PhpWord\\Writer\\ODText',
                 $object->getWriterPart($part)->getParentWriter()
             );
         }
@@ -52,7 +52,7 @@ class ODTextTest extends \PHPUnit\Framework\TestCase
     /**
      * Construct with null
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      * @expectedExceptionMessage No PhpWord assigned.
      */
     public function testConstructWithNull()
@@ -136,7 +136,7 @@ class ODTextTest extends \PHPUnit\Framework\TestCase
     /**
      * Use disk caching exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      */
     public function testSetUseDiskCachingException()
     {

--- a/tests/PhpWord/Writer/PDF/DomPDFTest.php
+++ b/tests/PhpWord/Writer/PDF/DomPDFTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\PDF;
+namespace Shareforce\PhpWord\Writer\PDF;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Writer\PDF;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Writer\PDF;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\PDF\DomPDF
+ * Test class for Shareforce\PhpWord\Writer\PDF\DomPDF
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Writer/PDF/MPDFTest.php
+++ b/tests/PhpWord/Writer/PDF/MPDFTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\PDF;
+namespace Shareforce\PhpWord\Writer\PDF;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Writer\PDF;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Writer\PDF;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\PDF\MPDF
+ * Test class for Shareforce\PhpWord\Writer\PDF\MPDF
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Writer/PDF/TCPDFTest.php
+++ b/tests/PhpWord/Writer/PDF/TCPDFTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\PDF;
+namespace Shareforce\PhpWord\Writer\PDF;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Writer\PDF;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\Writer\PDF;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\PDF\TCPDF
+ * Test class for Shareforce\PhpWord\Writer\PDF\TCPDF
  *
  * @runTestsInSeparateProcesses
  */

--- a/tests/PhpWord/Writer/PDFTest.php
+++ b/tests/PhpWord/Writer/PDFTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\PDF
+ * Test class for Shareforce\PhpWord\Writer\PDF
  *
  * @runTestsInSeparateProcesses
  */
@@ -49,7 +49,7 @@ class PDFTest extends \PHPUnit\Framework\TestCase
     /**
      * Test construct exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      * @expectedExceptionMessage PDF rendering library or library path has not been defined.
      */
     public function testConstructException()

--- a/tests/PhpWord/Writer/RTF/ElementTest.php
+++ b/tests/PhpWord/Writer/RTF/ElementTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF;
+namespace Shareforce\PhpWord\Writer\RTF;
 
-use PhpOffice\PhpWord\Writer\RTF;
+use Shareforce\PhpWord\Writer\RTF;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\RTF\Element subnamespace
+ * Test class for Shareforce\PhpWord\Writer\RTF\Element subnamespace
  */
 class ElementTest extends \PHPUnit\Framework\TestCase
 {
@@ -36,9 +36,9 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     {
         $elements = array('Container', 'Text', 'Title', 'Link', 'Image', 'Table', 'Field');
         foreach ($elements as $element) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\RTF\\Element\\' . $element;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\RTF\\Element\\' . $element;
             $parentWriter = new RTF();
-            $newElement = new \PhpOffice\PhpWord\Element\PageBreak();
+            $newElement = new \Shareforce\PhpWord\Element\PageBreak();
             $object = new $objectClass($parentWriter, $newElement);
 
             $this->assertEquals('', $object->write());
@@ -48,8 +48,8 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testPageField()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Field('PAGE');
-        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+        $element = new \Shareforce\PhpWord\Element\Field('PAGE');
+        $field = new \Shareforce\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
         $this->assertEquals("{\\field{\\*\\fldinst PAGE}{\\fldrslt}}\\par\n", $this->removeCr($field));
     }
@@ -57,8 +57,8 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testNumpageField()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Field('NUMPAGES');
-        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+        $element = new \Shareforce\PhpWord\Element\Field('NUMPAGES');
+        $field = new \Shareforce\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
         $this->assertEquals("{\\field{\\*\\fldinst NUMPAGES}{\\fldrslt}}\\par\n", $this->removeCr($field));
     }
@@ -66,8 +66,8 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testDateField()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Field('DATE', array('dateformat' => 'd MM yyyy H:mm:ss'));
-        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+        $element = new \Shareforce\PhpWord\Element\Field('DATE', array('dateformat' => 'd MM yyyy H:mm:ss'));
+        $field = new \Shareforce\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
         $this->assertEquals("{\\field{\\*\\fldinst DATE \\\\@ \"d MM yyyy H:mm:ss\"}{\\fldrslt}}\\par\n", $this->removeCr($field));
     }
@@ -75,8 +75,8 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testIndexField()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Field('INDEX');
-        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+        $element = new \Shareforce\PhpWord\Element\Field('INDEX');
+        $field = new \Shareforce\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
         $this->assertEquals("{}\\par\n", $this->removeCr($field));
     }
@@ -84,7 +84,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testTable()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Table();
+        $element = new \Shareforce\PhpWord\Element\Table();
         $width = 100;
         $width2 = 2 * $width;
         $element->addRow();
@@ -97,7 +97,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $tce->addText('3');
         $tce = $element->addCell($width);
         $tce->addText('4');
-        $table = new \PhpOffice\PhpWord\Writer\RTF\Element\Table($parentWriter, $element);
+        $table = new \Shareforce\PhpWord\Writer\RTF\Element\Table($parentWriter, $element);
         $expect = implode("\n", array(
             '\\pard',
             "\\trowd \\cellx$width \\cellx$width2 ",
@@ -126,10 +126,10 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testTextRun()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\TextRun();
+        $element = new \Shareforce\PhpWord\Element\TextRun();
         $element->addText('Hello ');
         $element->addText('there.');
-        $textrun = new \PhpOffice\PhpWord\Writer\RTF\Element\TextRun($parentWriter, $element);
+        $textrun = new \Shareforce\PhpWord\Writer\RTF\Element\TextRun($parentWriter, $element);
         $expect = "\\pard\\nowidctlpar {{\\cf0\\f0 Hello }{\\cf0\\f0 there.}}\\par\n";
         $this->assertEquals($expect, $this->removeCr($textrun));
     }
@@ -137,10 +137,10 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testTextRunParagraphStyle()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\TextRun(array('spaceBefore' => 0, 'spaceAfter' => 0));
+        $element = new \Shareforce\PhpWord\Element\TextRun(array('spaceBefore' => 0, 'spaceAfter' => 0));
         $element->addText('Hello ');
         $element->addText('there.');
-        $textrun = new \PhpOffice\PhpWord\Writer\RTF\Element\TextRun($parentWriter, $element);
+        $textrun = new \Shareforce\PhpWord\Writer\RTF\Element\TextRun($parentWriter, $element);
         $expect = "\\pard\\nowidctlpar \\sb0\\sa0{{\\cf0\\f0 Hello }{\\cf0\\f0 there.}}\\par\n";
         $this->assertEquals($expect, $this->removeCr($textrun));
     }
@@ -148,11 +148,11 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     public function testTitle()
     {
         $parentWriter = new RTF();
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $phpWord->addTitleStyle(1, array(), array('spaceBefore' => 0, 'spaceAfter' => 0));
         $section = $phpWord->addSection();
         $element = $section->addTitle('First Heading', 1);
-        $elwrite = new \PhpOffice\PhpWord\Writer\RTF\Element\Title($parentWriter, $element);
+        $elwrite = new \Shareforce\PhpWord\Writer\RTF\Element\Title($parentWriter, $element);
         $expect = "\\pard\\nowidctlpar \\sb0\\sa0{\\outlinelevel0{\\cf0\\f0 First Heading}\\par\n}";
         $this->assertEquals($expect, $this->removeCr($elwrite));
     }

--- a/tests/PhpWord/Writer/RTF/HeaderFooterTest.php
+++ b/tests/PhpWord/Writer/RTF/HeaderFooterTest.php
@@ -15,19 +15,19 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF;
+namespace Shareforce\PhpWord\Writer\RTF;
 
-use PhpOffice\PhpWord\Element\Footer;
-use PhpOffice\PhpWord\Writer\RTF;
+use Shareforce\PhpWord\Element\Footer;
+use Shareforce\PhpWord\Writer\RTF;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\RTF\Element subnamespace
+ * Test class for Shareforce\PhpWord\Writer\RTF\Element subnamespace
  */
 class HeaderFooterTest extends \PHPUnit\Framework\TestCase
 {
     public function testNoHeaderNoFooter()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $parentWriter = new RTF($phpWord);
         $section = $phpWord->addSection();
         $section->addText('Doc without header or footer');
@@ -40,7 +40,7 @@ class HeaderFooterTest extends \PHPUnit\Framework\TestCase
 
     public function testNoHeaderYesFooter()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $parentWriter = new RTF($phpWord);
         $section = $phpWord->addSection();
         $footer = $section->addFooter();
@@ -55,7 +55,7 @@ class HeaderFooterTest extends \PHPUnit\Framework\TestCase
 
     public function testEvenHeaderFirstFooter()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $phpWord->getSettings()->setEvenAndOddHeaders(true);
         $parentWriter = new RTF($phpWord);
         $section = $phpWord->addSection();

--- a/tests/PhpWord/Writer/RTF/StyleTest.php
+++ b/tests/PhpWord/Writer/RTF/StyleTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\RTF;
+namespace Shareforce\PhpWord\Writer\RTF;
 
-use PhpOffice\PhpWord\Writer\RTF;
-use PhpOffice\PhpWord\Writer\RTF\Style\Border;
 use PHPUnit\Framework\Assert;
+use Shareforce\PhpWord\Writer\RTF;
+use Shareforce\PhpWord\Writer\RTF\Style\Border;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\RTF\Style subnamespace
+ * Test class for Shareforce\PhpWord\Writer\RTF\Style subnamespace
  */
 class StyleTest extends \PHPUnit\Framework\TestCase
 {
@@ -38,7 +38,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     {
         $styles = array('Font', 'Paragraph', 'Section', 'Tab', 'Indentation');
         foreach ($styles as $style) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\RTF\\Style\\' . $style;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\RTF\\Style\\' . $style;
             $object = new $objectClass();
 
             $this->assertEquals('', $object->write());
@@ -65,12 +65,12 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
     public function testIndentation()
     {
-        $indentation = new \PhpOffice\PhpWord\Style\Indentation();
+        $indentation = new \Shareforce\PhpWord\Style\Indentation();
         $indentation->setLeft(1);
         $indentation->setRight(2);
         $indentation->setFirstLine(3);
 
-        $indentWriter = new \PhpOffice\PhpWord\Writer\RTF\Style\Indentation($indentation);
+        $indentWriter = new \Shareforce\PhpWord\Writer\RTF\Style\Indentation($indentation);
         $indentWriter->setParentWriter(new RTF());
         $result = $indentWriter->write();
 
@@ -79,11 +79,11 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
     public function testRightTab()
     {
-        $tabRight = new \PhpOffice\PhpWord\Style\Tab();
-        $tabRight->setType(\PhpOffice\PhpWord\Style\Tab::TAB_STOP_RIGHT);
+        $tabRight = new \Shareforce\PhpWord\Style\Tab();
+        $tabRight->setType(\Shareforce\PhpWord\Style\Tab::TAB_STOP_RIGHT);
         $tabRight->setPosition(5);
 
-        $tabWriter = new \PhpOffice\PhpWord\Writer\RTF\Style\Tab($tabRight);
+        $tabWriter = new \Shareforce\PhpWord\Writer\RTF\Style\Tab($tabRight);
         $tabWriter->setParentWriter(new RTF());
         $result = $tabWriter->write();
 
@@ -92,10 +92,10 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
     public function testCenterTab()
     {
-        $tabRight = new \PhpOffice\PhpWord\Style\Tab();
-        $tabRight->setType(\PhpOffice\PhpWord\Style\Tab::TAB_STOP_CENTER);
+        $tabRight = new \Shareforce\PhpWord\Style\Tab();
+        $tabRight->setType(\Shareforce\PhpWord\Style\Tab::TAB_STOP_CENTER);
 
-        $tabWriter = new \PhpOffice\PhpWord\Writer\RTF\Style\Tab($tabRight);
+        $tabWriter = new \Shareforce\PhpWord\Writer\RTF\Style\Tab($tabRight);
         $tabWriter->setParentWriter(new RTF());
         $result = $tabWriter->write();
 
@@ -104,10 +104,10 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
     public function testDecimalTab()
     {
-        $tabRight = new \PhpOffice\PhpWord\Style\Tab();
-        $tabRight->setType(\PhpOffice\PhpWord\Style\Tab::TAB_STOP_DECIMAL);
+        $tabRight = new \Shareforce\PhpWord\Style\Tab();
+        $tabRight->setType(\Shareforce\PhpWord\Style\Tab::TAB_STOP_DECIMAL);
 
-        $tabWriter = new \PhpOffice\PhpWord\Writer\RTF\Style\Tab($tabRight);
+        $tabWriter = new \Shareforce\PhpWord\Writer\RTF\Style\Tab($tabRight);
         $tabWriter->setParentWriter(new RTF());
         $result = $tabWriter->write();
 
@@ -117,8 +117,8 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testRTL()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Text('אב גד', array('RTL'=> true));
-        $text = new \PhpOffice\PhpWord\Writer\RTF\Element\Text($parentWriter, $element);
+        $element = new \Shareforce\PhpWord\Element\Text('אב גד', array('RTL'=> true));
+        $text = new \Shareforce\PhpWord\Writer\RTF\Element\Text($parentWriter, $element);
         $expect = "\\pard\\nowidctlpar {\\rtlch\\cf0\\f0 \\uc0{\\u1488}\\uc0{\\u1489} \\uc0{\\u1490}\\uc0{\\u1491}}\\par\n";
         $this->assertEquals($expect, $this->removeCr($text));
     }
@@ -126,8 +126,8 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testPageBreakLineHeight()
     {
         $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Text('New page', null, array('lineHeight' => 1.08, 'pageBreakBefore' => true));
-        $text = new \PhpOffice\PhpWord\Writer\RTF\Element\Text($parentWriter, $element);
+        $element = new \Shareforce\PhpWord\Element\Text('New page', null, array('lineHeight' => 1.08, 'pageBreakBefore' => true));
+        $text = new \Shareforce\PhpWord\Writer\RTF\Element\Text($parentWriter, $element);
         $expect = "\\pard\\nowidctlpar \\sl259\\slmult1\\page{\\cf0\\f0 New page}\\par\n";
         $this->assertEquals($expect, $this->removeCr($text));
     }
@@ -135,9 +135,9 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testPageNumberRestart()
     {
         //$parentWriter = new RTF();
-        $phpword = new \PhpOffice\PhpWord\PhpWord();
+        $phpword = new \Shareforce\PhpWord\PhpWord();
         $section = $phpword->addSection(array('pageNumberingStart' => 5));
-        $styleWriter = new \PhpOffice\PhpWord\Writer\RTF\Style\Section($section->getStyle());
+        $styleWriter = new \Shareforce\PhpWord\Writer\RTF\Style\Section($section->getStyle());
         $wstyle = $this->removeCr($styleWriter);
         // following have default values which might change so don't use them
         $wstyle = preg_replace('/\\\\pgwsxn\\d+/', '', $wstyle);

--- a/tests/PhpWord/Writer/RTFTest.php
+++ b/tests/PhpWord/Writer/RTFTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\RTF
+ * Test class for Shareforce\PhpWord\Writer\RTF
  *
  * @runTestsInSeparateProcesses
  */
@@ -34,13 +34,13 @@ class RTFTest extends \PHPUnit\Framework\TestCase
     {
         $object = new RTF(new PhpWord());
 
-        $this->assertInstanceOf('PhpOffice\\PhpWord\\PhpWord', $object->getPhpWord());
+        $this->assertInstanceOf('Shareforce\\PhpWord\\PhpWord', $object->getPhpWord());
     }
 
     /**
      * Construct with null
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      * @expectedExceptionMessage No PhpWord assigned.
      */
     public function testConstructWithNull()

--- a/tests/PhpWord/Writer/Word2007/Element/ChartTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/ChartTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007;
+namespace Shareforce\PhpWord\Writer\Word2007;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Element subnamespace
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Element subnamespace
  */
 class ChartTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+namespace Shareforce\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\TestHelperDOCX;
 use PHPUnit\Framework\TestCase;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Field
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Field
  */
 class FieldTest extends TestCase
 {

--- a/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\TestHelperDOCX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\Word2007\Field
+ */
+class FieldTest extends TestCase
+{
+    /**
+     * Executed before each method of the class
+     */
+    public function tearDown()
+    {
+        TestHelperDOCX::clear();
+    }
+
+    /**
+     * Test Field write
+     */
+    public function testWriteWithRefType()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addField(
+            'REF',
+            array(
+                'name' => 'my-bookmark',
+            ),
+            array(
+                'InsertParagraphNumberRelativeContext',
+                'CreateHyperLink',
+            )
+        );
+
+        $section->addListItem('line one item');
+        $section->addListItem('line two item');
+        $section->addBookmark('my-bookmark');
+        $section->addListItem('line three item');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $refFieldPath = '/w:document/w:body/w:p[1]/w:r[2]/w:instrText';
+
+        $this->assertTrue($doc->elementExists($refFieldPath));
+
+        $bookMarkElement = $doc->getElement($refFieldPath);
+
+        $this->assertNotNull($bookMarkElement);
+
+        $this->assertEquals(' REF my-bookmark \r \h ', $bookMarkElement->textContent);
+
+        $bookmarkPath = '/w:document/w:body/w:bookmarkStart';
+
+        $this->assertTrue($doc->elementExists($bookmarkPath));
+        $this->assertEquals('my-bookmark', $doc->getElementAttribute("$bookmarkPath", 'w:name'));
+    }
+}

--- a/tests/PhpWord/Writer/Word2007/Element/FormFieldTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/FormFieldTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007;
+namespace Shareforce\PhpWord\Writer\Word2007;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Element subnamespace
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Element subnamespace
  */
 class FormFieldTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWord/Writer/Word2007/ElementTest.php
@@ -15,17 +15,17 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007;
+namespace Shareforce\PhpWord\Writer\Word2007;
 
-use PhpOffice\PhpWord\Element\Comment;
-use PhpOffice\PhpWord\Element\TextRun;
-use PhpOffice\PhpWord\Element\TrackChange;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\XMLWriter;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\Element\Comment;
+use Shareforce\PhpWord\Element\TextRun;
+use Shareforce\PhpWord\Element\TrackChange;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Element subnamespace
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Element subnamespace
  */
 class ElementTest extends \PHPUnit\Framework\TestCase
 {
@@ -48,9 +48,9 @@ class ElementTest extends \PHPUnit\Framework\TestCase
             'Field', 'Line', 'Shape', 'Chart', 'FormField', 'SDT', 'Bookmark',
         );
         foreach ($elements as $element) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $element;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\Word2007\\Element\\' . $element;
             $xmlWriter = new XMLWriter();
-            $newElement = new \PhpOffice\PhpWord\Element\PageBreak();
+            $newElement = new \Shareforce\PhpWord\Element\PageBreak();
             $object = new $objectClass($xmlWriter, $newElement);
             $object->write();
 
@@ -120,7 +120,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
 
-        $table = $section->addTable(array('alignment' => \PhpOffice\PhpWord\SimpleType\JcTable::CENTER));
+        $table = $section->addTable(array('alignment' => \Shareforce\PhpWord\SimpleType\JcTable::CENTER));
         $table->addRow(900);
         $table->addCell(2000)->addText('Row 1');
         $table->addCell(2000)->addText('Row 2');
@@ -490,7 +490,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testTextWithAmpersant()
     {
-        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
+        \Shareforce\PhpWord\Settings::setOutputEscapingEnabled(true);
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
         $section->addText('this text contains an & (ampersant)');

--- a/tests/PhpWord/Writer/Word2007/Part/AbstractPartTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/AbstractPartTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Writer\Word2007;
+use Shareforce\PhpWord\Writer\Word2007;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\AbstractWriterPart
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\AbstractWriterPart
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\AbstractWriterPart
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Part\AbstractWriterPart
  * @runTestsInSeparateProcesses
  */
 class AbstractPartTest extends \PHPUnit\Framework\TestCase
@@ -33,7 +33,7 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetParentWriter()
     {
-        $object = $this->getMockForAbstractClass('PhpOffice\\PhpWord\\Writer\\Word2007\\Part\\AbstractPart');
+        $object = $this->getMockForAbstractClass('Shareforce\\PhpWord\\Writer\\Word2007\\Part\\AbstractPart');
         $object->setParentWriter(new Word2007());
         $this->assertEquals(new Word2007(), $object->getParentWriter());
     }
@@ -46,7 +46,7 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetParentWriterNull()
     {
-        $object = $this->getMockForAbstractClass('PhpOffice\\PhpWord\\Writer\\Word2007\\Part\\AbstractPart');
+        $object = $this->getMockForAbstractClass('Shareforce\\PhpWord\\Writer\\Word2007\\Part\\AbstractPart');
         $object->getParentWriter();
     }
 }

--- a/tests/PhpWord/Writer/Word2007/Part/CommentsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/CommentsTest.php
@@ -15,13 +15,13 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Comment
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\Comment
  *
  * @runTestsInSeparateProcesses
  */
@@ -40,7 +40,7 @@ class CommentsTest extends \PHPUnit\Framework\TestCase
      */
     public function testWriteComments()
     {
-        $comment = new \PhpOffice\PhpWord\Element\Comment('Authors name', new \DateTime(), 'my_initials');
+        $comment = new \Shareforce\PhpWord\Element\Comment('Authors name', new \DateTime(), 'my_initials');
         $comment->addText('Test');
 
         $phpWord = new PhpWord();

--- a/tests/PhpWord/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/DocumentTest.php
@@ -15,19 +15,19 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\ComplexType\FootnoteProperties;
-use PhpOffice\PhpWord\Metadata\DocInfo;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\SimpleType\NumberFormat;
-use PhpOffice\PhpWord\Style\Cell;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\ComplexType\FootnoteProperties;
+use Shareforce\PhpWord\Metadata\DocInfo;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\NumberFormat;
+use Shareforce\PhpWord\Style\Cell;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Document
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\Document
  *
  * @runTestsInSeparateProcesses
  */
@@ -214,7 +214,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
     {
         $objectSrc = __DIR__ . '/../../../_files/documents/sheet.xls';
 
-        $tabs = array(new \PhpOffice\PhpWord\Style\Tab('right', 9090));
+        $tabs = array(new \Shareforce\PhpWord\Style\Tab('right', 9090));
         $phpWord = new PhpWord();
         $phpWord->addParagraphStyle(
             'pStyle',

--- a/tests/PhpWord/Writer/Word2007/Part/FooterTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/FooterTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Writer\Word2007;
+use Shareforce\PhpWord\Writer\Word2007;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Footer
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\Footer
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\Footer
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Part\Footer
  * @runTestsInSeparateProcesses
  */
 class FooterTest extends \PHPUnit\Framework\TestCase
@@ -33,7 +33,7 @@ class FooterTest extends \PHPUnit\Framework\TestCase
     public function testWriteFooter()
     {
         $imageSrc = __DIR__ . '/../../../_files/images/PhpWord.png';
-        $container = new \PhpOffice\PhpWord\Element\Footer(1);
+        $container = new \Shareforce\PhpWord\Element\Footer(1);
         $container->addText('');
         $container->addPreserveText('');
         $container->addTextBreak();

--- a/tests/PhpWord/Writer/Word2007/Part/FootnotesTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/FootnotesTest.php
@@ -15,11 +15,11 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
  * @coversNothing

--- a/tests/PhpWord/Writer/Word2007/Part/HeaderTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/HeaderTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\Writer\Word2007;
+use Shareforce\PhpWord\Writer\Word2007;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Header
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\Header
  *
  * @runTestsInSeparateProcesses
  */
@@ -33,7 +33,7 @@ class HeaderTest extends \PHPUnit\Framework\TestCase
     {
         $imageSrc = __DIR__ . '/../../../_files/images/PhpWord.png';
 
-        $container = new \PhpOffice\PhpWord\Element\Header(1);
+        $container = new \Shareforce\PhpWord\Element\Header(1);
         $container->addText('Test');
         $container->addPreserveText('');
         $container->addTextBreak();

--- a/tests/PhpWord/Writer/Word2007/Part/NumberingTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/NumberingTest.php
@@ -15,17 +15,17 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\SimpleType\NumberFormat;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\SimpleType\NumberFormat;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Numbering
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\Numbering
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\Numbering
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Part\Numbering
  * @runTestsInSeparateProcesses
  * @since 0.10.0
  */

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -15,20 +15,20 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\ComplexType\ProofState;
-use PhpOffice\PhpWord\ComplexType\TrackChangesView;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Shared\Microsoft\PasswordEncoder;
-use PhpOffice\PhpWord\SimpleType\Zoom;
-use PhpOffice\PhpWord\Style\Language;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\ComplexType\ProofState;
+use Shareforce\PhpWord\ComplexType\TrackChangesView;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\Shared\Microsoft\PasswordEncoder;
+use Shareforce\PhpWord\SimpleType\Zoom;
+use Shareforce\PhpWord\Style\Language;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Settings
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\Settings
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\Settings
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Part\Settings
  */
 class SettingsTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Writer/Word2007/Part/StylesTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/StylesTest.php
@@ -15,18 +15,18 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Part;
+namespace Shareforce\PhpWord\Writer\Word2007\Part;
 
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Paragraph;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\Style\Font;
+use Shareforce\PhpWord\Style\Paragraph;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Styles
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part\Styles
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\Styles
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Part\Styles
  * @runTestsInSeparateProcesses
  */
 class StylesTest extends \PHPUnit\Framework\TestCase

--- a/tests/PhpWord/Writer/Word2007/PartTest.php
+++ b/tests/PhpWord/Writer/Word2007/PartTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007;
+namespace Shareforce\PhpWord\Writer\Word2007;
 
-use PhpOffice\PhpWord\Writer\Word2007\Part\RelsPart;
+use Shareforce\PhpWord\Writer\Word2007\Part\RelsPart;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Part subnamespace
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Part subnamespace
  *
  * Covers miscellaneous tests
  */
@@ -29,8 +29,8 @@ class PartTest extends \PHPUnit\Framework\TestCase
     /**
      * Test exception when no type or target assigned to a relation
      *
-     * @covers \PhpOffice\PhpWord\Writer\Word2007\Part\Rels::writeRel
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @covers \Shareforce\PhpWord\Writer\Word2007\Part\Rels::writeRel
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      * @expectedExceptionMessage Invalid parameters passed.
      */
     public function testRelsWriteRelException()

--- a/tests/PhpWord/Writer/Word2007/Style/FontTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/FontTest.php
@@ -15,14 +15,14 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Style\Font
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Style\Font
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Style\Font
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Style\Font
  * @runTestsInSeparateProcesses
  */
 class FontTest extends \PHPUnit\Framework\TestCase
@@ -40,7 +40,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testFontRTL()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $textrun = $section->addTextRun();
         $textrun->addText('سلام این یک پاراگراف راست به چپ است', array('rtl' => true, 'lang' => 'ar-DZ'));
@@ -53,7 +53,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
 
     public function testFontRTLNamed()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $stnam = 'fstyle';
         $phpWord->addFontStyle($stnam, array(
             'rtl'  => true,
@@ -78,7 +78,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
 
     public function testFontNotRTLNamed()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $stnam = 'fstyle';
         $phpWord->addFontStyle($stnam, array(
             //'rtl'  => true,
@@ -103,7 +103,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
 
     public function testNoProof()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $fontStyle = array(
             'noProof' => true,
             'name'    => 'Courier New',
@@ -130,9 +130,9 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testFontWithLang()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
-        $section->addText('Ce texte-ci est en français.', array('lang' => \PhpOffice\PhpWord\Style\Language::FR_BE));
+        $section->addText('Ce texte-ci est en français.', array('lang' => \Shareforce\PhpWord\Style\Language::FR_BE));
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
 
         $file = 'word/document.xml';
@@ -145,7 +145,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
      */
     public function testPosition()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('This text is lowered', array('position' => -20));
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');

--- a/tests/PhpWord/Writer/Word2007/Style/ImageTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/ImageTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Style\Image;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\Style\Image;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Style\Font
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Style\Font
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Style\Frame
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Style\Frame
  * @runTestsInSeparateProcesses
  */
 class ImageTest extends \PHPUnit\Framework\TestCase
@@ -49,7 +49,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             'wrapDistanceBottom' => 40,
         );
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addImage(__DIR__ . '/../../../_files/images/earth.jpg', $styles);
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
@@ -83,7 +83,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
             'position'           => 10,
         );
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addImage(__DIR__ . '/../../../_files/images/earth.jpg', $styles);
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');

--- a/tests/PhpWord/Writer/Word2007/Style/ParagraphTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/ParagraphTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\Style\Paragraph as ParagraphStyle;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Style\Paragraph
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Style\Paragraph
  * @runTestsInSeparateProcesses
  */
 class ParagraphTest extends \PHPUnit\Framework\TestCase
@@ -41,7 +41,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
      */
     public function testParagraphNumbering()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $phpWord->addParagraphStyle('testStyle', array('indent' => '10'));
         $section = $phpWord->addSection();
         $section->addText('test', null, array('numStyle' => 'testStyle', 'numLevel' => '1'));
@@ -53,7 +53,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
 
     public function testLineSpacingExact()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('test', null, array('spacing' => 240, 'spacingLineRule' => 'exact'));
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
@@ -66,7 +66,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
 
     public function testLineSpacingAuto()
     {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('test', null, array('spacing' => 240, 'spacingLineRule' => 'auto'));
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
@@ -82,7 +82,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
         $paragraphStyle = new ParagraphStyle();
         $paragraphStyle->setSuppressAutoHyphens(true);
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->addText('test', null, $paragraphStyle);
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');

--- a/tests/PhpWord/Writer/Word2007/Style/SectionTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/SectionTest.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\Settings;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Style\Section
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Style\Section
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Style\Section
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Style\Section
  * @runTestsInSeparateProcesses
  */
 class SectionTest extends \PHPUnit\Framework\TestCase
@@ -39,9 +39,9 @@ class SectionTest extends \PHPUnit\Framework\TestCase
     public function testMarginInInches()
     {
         $unit = Settings::getMeasurementUnit();
-        Settings::setMeasurementUnit(\PhpOffice\PhpWord\Settings::UNIT_INCH);
+        Settings::setMeasurementUnit(\Shareforce\PhpWord\Settings::UNIT_INCH);
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $section->getStyle()->setMarginTop(0.1)->setMarginBottom(0.4)->setMarginLeft(0.2)->setMarginRight(0.3);
         $section->addText('test');

--- a/tests/PhpWord/Writer/Word2007/Style/TableTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/TableTest.php
@@ -15,18 +15,18 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+namespace Shareforce\PhpWord\Writer\Word2007\Style;
 
-use PhpOffice\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
-use PhpOffice\PhpWord\SimpleType\TblWidth;
-use PhpOffice\PhpWord\Style\Table;
-use PhpOffice\PhpWord\Style\TablePosition;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
+use Shareforce\PhpWord\SimpleType\TblWidth;
+use Shareforce\PhpWord\Style\Table;
+use Shareforce\PhpWord\Style\TablePosition;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Style\Table
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Style\Table
  *
- * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Style\Table
+ * @coversDefaultClass \Shareforce\PhpWord\Writer\Word2007\Style\Table
  * @runTestsInSeparateProcesses
  */
 class TableTest extends \PHPUnit\Framework\TestCase
@@ -47,7 +47,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $tableStyle = new Table();
         $tableStyle->setLayout(Table::LAYOUT_FIXED);
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $table = $section->addTable($tableStyle);
         $table->addRow();
@@ -67,7 +67,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $tableStyle = new Table();
         $tableStyle->setCellSpacing(10.3);
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $table = $section->addTable($tableStyle);
         $table->addRow();
@@ -100,7 +100,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $tableStyle = new Table();
         $tableStyle->setPosition($tablePosition);
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $table = $section->addTable($tableStyle);
         $table->addRow();
@@ -129,7 +129,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $tableStyle = new Table();
         $tableStyle->setIndent(new TblWidthComplexType($value, $type));
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $table = $section->addTable($tableStyle);
         $table->addRow();
@@ -147,7 +147,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $tableStyle = new Table();
         $tableStyle->setBidiVisual(true);
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new \Shareforce\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $table = $section->addTable($tableStyle);
         $table->addRow();

--- a/tests/PhpWord/Writer/Word2007/StyleTest.php
+++ b/tests/PhpWord/Writer/Word2007/StyleTest.php
@@ -15,12 +15,12 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer\Word2007;
+namespace Shareforce\PhpWord\Writer\Word2007;
 
-use PhpOffice\PhpWord\Shared\XMLWriter;
+use Shareforce\PhpWord\Shared\XMLWriter;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007\Style subnamespace
+ * Test class for Shareforce\PhpWord\Writer\Word2007\Style subnamespace
  */
 class StyleTest extends \PHPUnit\Framework\TestCase
 {
@@ -35,7 +35,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
             'TextBox', 'Line', 'Shape', 'Frame', 'Outline', 'Fill', 'Shadow', 'Extrusion',
         );
         foreach ($styles as $style) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Style\\' . $style;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\Word2007\\Style\\' . $style;
             $xmlWriter = new XMLWriter();
             $object = new $objectClass($xmlWriter);
             $object->write();
@@ -55,7 +55,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
             'TextBox'   => 'writeBorder',
         );
         foreach ($styles as $style => $method) {
-            $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Style\\' . $style;
+            $objectClass = 'Shareforce\\PhpWord\\Writer\\Word2007\\Style\\' . $style;
             $xmlWriter = new XMLWriter();
             $object = new $objectClass($xmlWriter);
             $object->$method();

--- a/tests/PhpWord/Writer/Word2007Test.php
+++ b/tests/PhpWord/Writer/Word2007Test.php
@@ -15,15 +15,15 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord\Writer;
+namespace Shareforce\PhpWord\Writer;
 
-use PhpOffice\PhpWord\AbstractWebServerEmbeddedTest;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\SimpleType\Jc;
-use PhpOffice\PhpWord\TestHelperDOCX;
+use Shareforce\PhpWord\AbstractWebServerEmbeddedTest;
+use Shareforce\PhpWord\PhpWord;
+use Shareforce\PhpWord\SimpleType\Jc;
+use Shareforce\PhpWord\TestHelperDOCX;
 
 /**
- * Test class for PhpOffice\PhpWord\Writer\Word2007
+ * Test class for Shareforce\PhpWord\Writer\Word2007
  *
  * @runTestsInSeparateProcesses
  */
@@ -60,11 +60,11 @@ class Word2007Test extends AbstractWebServerEmbeddedTest
         );
         foreach ($writerParts as $part => $type) {
             $this->assertInstanceOf(
-                "PhpOffice\\PhpWord\\Writer\\Word2007\\Part\\{$type}",
+                "Shareforce\\PhpWord\\Writer\\Word2007\\Part\\{$type}",
                 $object->getWriterPart($part)
             );
             $this->assertInstanceOf(
-                'PhpOffice\\PhpWord\\Writer\\Word2007',
+                'Shareforce\\PhpWord\\Writer\\Word2007',
                 $object->getWriterPart($part)->getParentWriter()
             );
         }
@@ -183,7 +183,7 @@ class Word2007Test extends AbstractWebServerEmbeddedTest
     /**
      * Use disk caching exception
      *
-     * @expectedException \PhpOffice\PhpWord\Exception\Exception
+     * @expectedException \Shareforce\PhpWord\Exception\Exception
      */
     public function testSetUseDiskCachingException()
     {

--- a/tests/PhpWord/_includes/AbstractTestReader.php
+++ b/tests/PhpWord/_includes/AbstractTestReader.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 /**
  * Base class for Word2007 reader tests
@@ -23,11 +23,11 @@ namespace PhpOffice\PhpWord;
 abstract class AbstractTestReader extends \PHPUnit\Framework\TestCase
 {
     private $parts = array(
-        'styles'     => array('class' => 'PhpOffice\PhpWord\Reader\Word2007\Styles',      'xml' => '<w:styles xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:docDefaults><w:rPrDefault><w:rPr><w:sz w:val="24"/></w:rPr></w:rPrDefault></w:docDefaults>{toReplace}</w:styles>'),
-        'document'   => array('class' => 'PhpOffice\PhpWord\Reader\Word2007\Document',    'xml' => '<w:document xmlns:v="urn:schemas-microsoft-com:vml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{toReplace}</w:body></w:document>'),
-        'footnotes'  => array('class' => 'PhpOffice\PhpWord\Reader\Word2007\Footnotes',   'xml' => '<w:footnotes xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">{toReplace}</w:footnotes>'),
-        'endnotes'   => array('class' => 'PhpOffice\PhpWord\Reader\Word2007\Endnotes',    'xml' => '<w:endnotes xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">{toReplace}</w:endnotes>'),
-        'settings'   => array('class' => 'PhpOffice\PhpWord\Reader\Word2007\Settings',    'xml' => '<w:comments xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">{toReplace}</w:comments>'),
+        'styles'     => array('class' => 'Shareforce\PhpWord\Reader\Word2007\Styles',      'xml' => '<w:styles xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:docDefaults><w:rPrDefault><w:rPr><w:sz w:val="24"/></w:rPr></w:rPrDefault></w:docDefaults>{toReplace}</w:styles>'),
+        'document'   => array('class' => 'Shareforce\PhpWord\Reader\Word2007\Document',    'xml' => '<w:document xmlns:v="urn:schemas-microsoft-com:vml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{toReplace}</w:body></w:document>'),
+        'footnotes'  => array('class' => 'Shareforce\PhpWord\Reader\Word2007\Footnotes',   'xml' => '<w:footnotes xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">{toReplace}</w:footnotes>'),
+        'endnotes'   => array('class' => 'Shareforce\PhpWord\Reader\Word2007\Endnotes',    'xml' => '<w:endnotes xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">{toReplace}</w:endnotes>'),
+        'settings'   => array('class' => 'Shareforce\PhpWord\Reader\Word2007\Settings',    'xml' => '<w:comments xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">{toReplace}</w:comments>'),
     );
 
     /**
@@ -35,7 +35,7 @@ abstract class AbstractTestReader extends \PHPUnit\Framework\TestCase
      *
      * @param string $documentXml
      * @param null|string $stylesXml
-     * @return \PhpOffice\PhpWord\PhpWord
+     * @return \Shareforce\PhpWord\PhpWord
      */
     protected function getDocumentFromString(array $partXmls = array())
     {

--- a/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
+++ b/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 use Symfony\Component\Process\Process;
 

--- a/tests/PhpWord/_includes/TestHelperDOCX.php
+++ b/tests/PhpWord/_includes/TestHelperDOCX.php
@@ -15,9 +15,9 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
-use PhpOffice\PhpWord\Exception\CreateTemporaryFileException;
+use Shareforce\PhpWord\Exception\CreateTemporaryFileException;
 
 /**
  * Test helper class
@@ -36,11 +36,11 @@ class TestHelperDOCX
      *
      * @since 0.12.0 Throws CreateTemporaryFileException.
      *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     * @param \Shareforce\PhpWord\PhpWord $phpWord
      * @param string $writerName
      *
-     * @throws \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
-     * @return \PhpOffice\PhpWord\XmlDocument
+     * @throws \Shareforce\PhpWord\Exception\CreateTemporaryFileException
+     * @return \Shareforce\PhpWord\XmlDocument
      */
     public static function getDocument(PhpWord $phpWord, $writerName = 'Word2007')
     {

--- a/tests/PhpWord/_includes/TestableTemplateProcesor.php
+++ b/tests/PhpWord/_includes/TestableTemplateProcesor.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 /**
  * This class is used to expose publicly methods that are otherwise private or protected.

--- a/tests/PhpWord/_includes/XmlDocument.php
+++ b/tests/PhpWord/_includes/XmlDocument.php
@@ -15,7 +15,7 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
-namespace PhpOffice\PhpWord;
+namespace Shareforce\PhpWord;
 
 /**
  * DOM wrapper class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,7 +25,7 @@ if (!defined('PHPWORD_TESTS_BASE_DIR')) {
 
 spl_autoload_register(function ($class) {
     $class = ltrim($class, '\\');
-    $prefix = 'PhpOffice\\PhpWord';
+    $prefix = 'Shareforce\\PhpWord';
     if (strpos($class, $prefix) === 0) {
         $class = str_replace('\\', DIRECTORY_SEPARATOR, $class);
         $class = implode(DIRECTORY_SEPARATOR, array('PhpWord', '_includes')) .


### PR DESCRIPTION
### Description

NB: Namespace was changed from PhpOffice to Shareforce

PHPOffice/PHPWord currently does not support adding the field of type REF.
I would like to add a field to reference a bookmark
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)
Add REF options to $fieldsArray in PhpOffice\PhpWord\Element\Field.php
Added writeRef method to Handle REF options

```php
$textRun->addField('REF', [
      'name' => 'my-bookmark'
  ], [
      'InsertParagraphNumberRelativeContext',
      'CreateHyperLink',
  ]);
```

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
